### PR TITLE
Protocol: add ResetSceneItem for resetting source items

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -100,6 +100,7 @@ The protocol in general is based on the OBS Remote protocol created by Bill Hami
       - ["SetSceneItemPosition"](#setsceneitemposition)
       - ["SetSceneItemTransform"](#setsceneitemtransform)
       - ["SetSceneItemCrop"](#setsceneitemcrop)
+      - ["ResetSceneItem"](#resetsceneitem)
     - **Scene Collections**
       - ["ListSceneCollections"](#listscenecollections)
       - ["SetCurrentSceneCollection"](#setcurrentscenecollection)
@@ -733,6 +734,15 @@ __Request fields__ :
 - **"bottom"** (integer)
 - **"left"** (integer)
 - **"right"** (integer)
+
+__Response__ : OK if specified item exists, error otherwise.
+
+---
+
+#### "ResetSceneItem"
+__Request fields__ :
+- **"item"** (string) : Name of the scene item
+- **"scene-name"** (string, optional) : Scene the item belongs to. Default : current scene.
 
 __Response__ : OK if specified item exists, error otherwise.
 

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -53,6 +53,7 @@ WSRequestHandler::WSRequestHandler(QWebSocket* client) :
 	messageMap["SetSceneItemPosition"] = WSRequestHandler::HandleSetSceneItemPosition;
 	messageMap["SetSceneItemTransform"] = WSRequestHandler::HandleSetSceneItemTransform;
 	messageMap["SetSceneItemCrop"] = WSRequestHandler::HandleSetSceneItemCrop;
+	messageMap["ResetSceneItem"] = WSRequestHandler::HandleResetSceneItem;
 
 	messageMap["GetStreamingStatus"] = WSRequestHandler::HandleGetStreamingStatus;
 	messageMap["StartStopStreaming"] = WSRequestHandler::HandleStartStopStreaming;
@@ -1707,5 +1708,47 @@ void WSRequestHandler::HandleSetBrowserSourceProperties(WSRequestHandler* req)
 	{
 		req->SendErrorResponse("specified scene item doesn't exist");
 	}
+	obs_source_release(scene);
+}
+
+void WSRequestHandler::HandleResetSceneItem(WSRequestHandler* req)
+{
+	if (!req->hasField("item"))
+	{
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
+
+	const char* itemName = obs_data_get_string(req->data, "item");
+
+	if (!itemName)
+	{
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
+
+	const char* sceneName = obs_data_get_string(req->data, "scene-name");
+	obs_source_t* scene = Utils::GetSceneFromNameOrCurrent(sceneName);
+	if (scene == NULL) {
+		req->SendErrorResponse("requested scene doesn't exist");
+		return;
+	}
+
+	obs_sceneitem_t* sceneItem = Utils::GetSceneItemFromName(scene, itemName);
+	if (sceneItem != NULL)
+	{
+		obs_source_t* sceneItemSource = obs_sceneitem_get_source(sceneItem);
+
+		obs_data_t* settings = obs_source_get_settings(sceneItemSource);
+		obs_source_update(sceneItemSource, settings);
+
+		obs_sceneitem_release(sceneItem);
+		req->SendOKResponse();
+	}
+	else
+	{
+		req->SendErrorResponse("specified scene item doesn't exist");
+	}
+
 	obs_source_release(scene);
 }

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -61,6 +61,7 @@ class WSRequestHandler : public QObject
 		static void HandleSetSceneItemPosition(WSRequestHandler* req);
 		static void HandleSetSceneItemTransform(WSRequestHandler* req);
 		static void HandleSetSceneItemCrop(WSRequestHandler* req);
+		static void HandleResetSceneItem(WSRequestHandler* req);
 
 		static void HandleGetStreamingStatus(WSRequestHandler* req);
 		static void HandleStartStopStreaming(WSRequestHandler* req);


### PR DESCRIPTION
Use case: Reset media sources for recovery of timed-out input streams.