### PR TITLE
Add request types: SetSyncOffset and GetSyncOffset

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -95,6 +95,8 @@ The protocol in general is based on the OBS Remote protocol created by Bill Hami
       - ["SetMute"](#setmute)
       - ["GetMute"](#getmute)
       - ["ToggleMute"](#togglemute)
+      - ["SetSyncOffset"](#setsyncoffset)
+      - ["GetSyncOffset"](#getsyncoffset)
     - **Scene Items**
       - ["SetSceneItemRender"](#setsourcerender) (a.k.a `SetSourceRender`)
       - ["SetSceneItemPosition"](#setsceneitemposition)
@@ -688,6 +690,29 @@ __Request fields__ :
 - **"source"** (string) : the name of the source
 
 __Response__ : OK if specified source exists, error otherwise.
+
+---
+
+#### "SetSyncOffset"
+Set the sync offset of a specific source.
+
+__Request fields__ :
+- **"source"** (string) : the name of the source
+- **"offset"** (integer) : the desired sync offset in nanoseconds
+
+__Response__ : OK if specified source exists, error otherwise.
+
+---
+
+#### "GetSyncOffset"
+Get the sync offset of a specific source.
+
+__Request fields__ :
+- **"source"** (string) : the name of the source
+
+__Response__ : OK if source exists, with these additional fields :
+- **"name"** (string) : source name
+- **"offset"** (integer) : source sync offset, in nanoseconds
 
 ---
 

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -77,8 +77,8 @@ WSRequestHandler::WSRequestHandler(QWebSocket* client) :
     messageMap["ToggleMute"] = WSRequestHandler::HandleToggleMute;
     messageMap["SetMute"] = WSRequestHandler::HandleSetMute;
     messageMap["GetMute"] = WSRequestHandler::HandleGetMute;
-	messageMap["SetSyncOffset"] = WSRequestHandler::HandleSetSyncOffset;
-	messageMap["GetSyncOffset"] = WSRequestHandler::HandleGetSyncOffset;
+    messageMap["SetSyncOffset"] = WSRequestHandler::HandleSetSyncOffset;
+    messageMap["GetSyncOffset"] = WSRequestHandler::HandleGetSyncOffset;
     messageMap["GetSpecialSources"] = WSRequestHandler::HandleGetSpecialSources;
 
     messageMap["SetCurrentSceneCollection"] = WSRequestHandler::HandleSetCurrentSceneCollection;
@@ -713,55 +713,55 @@ void WSRequestHandler::HandleGetMute(WSRequestHandler* req) {
 }
 
 void WSRequestHandler::HandleSetSyncOffset(WSRequestHandler* req) {
-	if (!req->hasField("source") ||
-		!req->hasField("offset")) {
-		req->SendErrorResponse("missing request parameters");
-		return;
-	}
+    if (!req->hasField("source") ||
+	!req->hasField("offset")) {
+	req->SendErrorResponse("missing request parameters");
+	return;
+    }
 
-	const char* source_name = obs_data_get_string(req->data, "source");
-	int64_t source_sync_offset = (int64_t)obs_data_get_int(req->data, "offset");
+    const char* source_name = obs_data_get_string(req->data, "source");
+    int64_t source_sync_offset = (int64_t)obs_data_get_int(req->data, "offset");
 
-	if (source_name == NULL || strlen(source_name) < 1 ||
-		source_sync_offset < 0 {
-		req->SendErrorResponse("invalid request parameters");
-		return;
-	}
+    if (source_name == NULL || strlen(source_name) < 1 ||
+	source_sync_offset < 0 {
+	req->SendErrorResponse("invalid request parameters");
+	return;
+    }
 
-	obs_source_t* source = obs_get_source_by_name(source_name);
-	if (!source) {
-		req->SendErrorResponse("specified source doesn't exist");
-		return;
-	}
+    obs_source_t* source = obs_get_source_by_name(source_name);
+    if (!source) {
+        req->SendErrorResponse("specified source doesn't exist");
+	return;
+    }
 
-	obs_source_set_sync_offset(source, source_sync_offset);
-	req->SendOKResponse();
+    obs_source_set_sync_offset(source, source_sync_offset);
+    req->SendOKResponse();
 
-	obs_source_release(source);
+    obs_source_release(source);
 }
 
 void WSRequestHandler::HandleGetSyncOffset(WSRequestHandler* req) {
-	if (!req->hasField("source")) {
-		req->SendErrorResponse("missing request parameters");
-		return;
-	}
+    if (!req->hasField("source")) {
+	req->SendErrorResponse("missing request parameters");
+	return;
+    }
 
-	const char* source_name = obs_data_get_string(req->data, "source");
-	if (str_valid(source_name)) {
-		obs_source_t* source = obs_get_source_by_name(source_name);
+    const char* source_name = obs_data_get_string(req->data, "source");
+    if (str_valid(source_name)) {
+	obs_source_t* source = obs_get_source_by_name(source_name);
 
-		obs_data_t* response = obs_data_create();
-		obs_data_set_string(response, "name", source_name);
-		obs_data_set_int(response, "offset", obs_source_get_sync_offset(source));
+	obs_data_t* response = obs_data_create();
+	obs_data_set_string(response, "name", source_name);
+	obs_data_set_int(response, "offset", obs_source_get_sync_offset(source));
 
-		req->SendOKResponse(response);
+	req->SendOKResponse(response);
 
-		obs_data_release(response);
-		obs_source_release(source);
-	}
-	else {
-		req->SendErrorResponse("invalid request parameters");
-	}
+	obs_data_release(response);
+	obs_source_release(source);
+    }
+    else {
+	req->SendErrorResponse("invalid request parameters");
+    }
 }
 
 void WSRequestHandler::HandleSetSceneItemPosition(WSRequestHandler* req) {

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -77,6 +77,8 @@ WSRequestHandler::WSRequestHandler(QWebSocket* client) :
     messageMap["ToggleMute"] = WSRequestHandler::HandleToggleMute;
     messageMap["SetMute"] = WSRequestHandler::HandleSetMute;
     messageMap["GetMute"] = WSRequestHandler::HandleGetMute;
+	messageMap["SetSyncOffset"] = WSRequestHandler::HandleSetSyncOffset;
+	messageMap["GetSyncOffset"] = WSRequestHandler::HandleGetSyncOffset;
     messageMap["GetSpecialSources"] = WSRequestHandler::HandleGetSpecialSources;
 
     messageMap["SetCurrentSceneCollection"] = WSRequestHandler::HandleSetCurrentSceneCollection;
@@ -708,6 +710,58 @@ void WSRequestHandler::HandleGetMute(WSRequestHandler* req) {
 
     obs_source_release(source);
     obs_data_release(response);
+}
+
+void WSRequestHandler::HandleSetSyncOffset(WSRequestHandler* req) {
+	if (!req->hasField("source") ||
+		!req->hasField("offset")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
+
+	const char* source_name = obs_data_get_string(req->data, "source");
+	int64_t source_sync_offset = (int64_t)obs_data_get_int(req->data, "offset");
+
+	if (source_name == NULL || strlen(source_name) < 1 ||
+		source_sync_offset < 0 {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
+
+	obs_source_t* source = obs_get_source_by_name(source_name);
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
+
+	obs_source_set_sync_offset(source, source_sync_offset);
+	req->SendOKResponse();
+
+	obs_source_release(source);
+}
+
+void WSRequestHandler::HandleGetSyncOffset(WSRequestHandler* req) {
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
+
+	const char* source_name = obs_data_get_string(req->data, "source");
+	if (str_valid(source_name)) {
+		obs_source_t* source = obs_get_source_by_name(source_name);
+
+		obs_data_t* response = obs_data_create();
+		obs_data_set_string(response, "name", source_name);
+		obs_data_set_int(response, "offset", obs_source_get_sync_offset(source));
+
+		req->SendOKResponse(response);
+
+		obs_data_release(response);
+		obs_source_release(source);
+	}
+	else {
+		req->SendErrorResponse("invalid request parameters");
+	}
 }
 
 void WSRequestHandler::HandleSetSceneItemPosition(WSRequestHandler* req) {

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -722,8 +722,8 @@ void WSRequestHandler::HandleSetSyncOffset(WSRequestHandler* req) {
     const char* source_name = obs_data_get_string(req->data, "source");
     int64_t source_sync_offset = (int64_t)obs_data_get_int(req->data, "offset");
 
-    if (source_name == NULL || strlen(source_name) < 1 ||
-	source_sync_offset < 0 {
+    if (!source_name || strlen(source_name) < 1 ||
+	source_sync_offset < 0) {
 	req->SendErrorResponse("invalid request parameters");
 	return;
     }

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -83,6 +83,8 @@ class WSRequestHandler : public QObject {
     static void HandleToggleMute(WSRequestHandler* req);
     static void HandleSetMute(WSRequestHandler* req);
     static void HandleGetMute(WSRequestHandler* req);
+	static void HandleSetSyncOffset(WSRequestHandler* req);
+	static void HandleGetSyncOffset(WSRequestHandler* req);
     static void HandleGetSpecialSources(WSRequestHandler* req);
 
     static void HandleSetCurrentSceneCollection(WSRequestHandler* req);

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -83,8 +83,8 @@ class WSRequestHandler : public QObject {
     static void HandleToggleMute(WSRequestHandler* req);
     static void HandleSetMute(WSRequestHandler* req);
     static void HandleGetMute(WSRequestHandler* req);
-	static void HandleSetSyncOffset(WSRequestHandler* req);
-	static void HandleGetSyncOffset(WSRequestHandler* req);
+    static void HandleSetSyncOffset(WSRequestHandler* req);
+    static void HandleGetSyncOffset(WSRequestHandler* req);
     static void HandleGetSpecialSources(WSRequestHandler* req);
 
     static void HandleSetCurrentSceneCollection(WSRequestHandler* req);


### PR DESCRIPTION
Adds those 2 request types for the functions "obs_source_set_sync_offset" and "obs_source_get_sync_offset". We plan to gracefully auto adjust an audio source delay to match a twitch stream (based on its delay). So this would be great to have!