### PR TITLE
Fix saving replay buffer when no hotkey is set

### DIFF
--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -780,13 +780,15 @@ void WSRequestHandler::HandleSaveReplayBuffer(WSRequestHandler* req) {
         return;
     }
 
-    obs_hotkey_t* hk = Utils::FindHotkeyByName("ReplayBuffer.Save");
-    if (hk) {
-        obs_hotkey_trigger_routed_callback(obs_hotkey_get_id(hk), true);
-        req->SendOKResponse();
-    } else {
-        req->SendErrorResponse("failed to save replay buffer");
-    }
+    calldata_t cd = {0};
+    obs_output_t* replay_output = obs_frontend_get_replay_buffer_output();
+    proc_handler_t* ph = obs_output_get_proc_handler(replay_output);
+    proc_handler_call(ph, "save", &cd);
+
+    req->SendOKResponse();
+
+    calldata_free(&cd);
+    obs_output_release(replay_output);
 }
 
 /**


### PR DESCRIPTION
This commit makes saving the replay buffer not rely on whether or not a hotkey is set in OBS.

This is a temporary follow-up to PR #104, issue #90, and [OBS Mantis Bug 955](https://obsproject.com/mantis/view.php?id=955) until the OBS Frontend API gets a built-in function for this.  I am also working on that, which is why I called this temporary.  However, PRs to OBS core may take longer to get merged than a PR here, so I'm submitting this PR for now.

Also, I couldn't see an easy way to detect a success/fail from OBS on saving the replay, so I made the function here simply return an OK message.  The only way right now to detect if a reply was saved would be to manually check if the file exists.

I've compiled and tested this on Windows 10 Pro 64-bit.  I wasn't sure about the commit guidelines on this project, so please feel free to edit this as needed.