### PR TITLE
Feature: monitor each input stream

### DIFF
--- a/WSEvents.cpp
+++ b/WSEvents.cpp
@@ -617,6 +617,7 @@ void WSEvents::StreamStatus() {
     bool streaming_active = obs_frontend_streaming_active();
     bool recording_active = obs_frontend_recording_active();
 
+    obs_output_t* stream_output = obs_frontend_get_streaming_output();
     obs_output_t* status_output = obs_frontend_get_streaming_output();
 
     if (recording_active) {

--- a/WSEvents.cpp
+++ b/WSEvents.cpp
@@ -51,7 +51,7 @@ const char* ns_to_timestamp(uint64_t ns) {
 
     char* ts = (char*)bmalloc(64);
     sprintf(ts, "%02d:%02d:%02d.%03d",
-        hours_part, minutes_part, secs_part, ms_part);
+        (int)hours_part, (int)minutes_part, (int)secs_part, (int)ms_part);
 
     return ts;
 }

--- a/WSEvents.cpp
+++ b/WSEvents.cpp
@@ -617,16 +617,20 @@ void WSEvents::StreamStatus() {
     bool streaming_active = obs_frontend_streaming_active();
     bool recording_active = obs_frontend_recording_active();
 
-    obs_output_t* stream_output = obs_frontend_get_streaming_output();
+    obs_output_t* status_output = obs_frontend_get_streaming_output();
 
-    if (!stream_output || !streaming_active) {
-        if (stream_output) {
-            obs_output_release(stream_output);
+    if (recording_active) {
+        status_output = obs_frontend_get_recording_output();
+    }
+
+    if (!status_output || (!streaming_active && !recording_active)) {
+        if (status_output) {
+            obs_output_release(status_output);
         }
         return;
     }
 
-    uint64_t bytes_sent = obs_output_get_total_bytes(stream_output);
+    uint64_t bytes_sent = obs_output_get_total_bytes(status_output);
     uint64_t bytes_sent_time = os_gettime_ns();
 
     if (bytes_sent < _lastBytesSent)

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -116,6 +116,8 @@ WSRequestHandler::WSRequestHandler(QWebSocket* client) :
     messageMap["GetBrowserSourceProperties"] = WSRequestHandler::HandleGetBrowserSourceProperties;
     messageMap["SetBrowserSourceProperties"] = WSRequestHandler::HandleSetBrowserSourceProperties;
 
+    messageMap["GetSourceData"] = WSRequestHandler::HandleGetSourceData;
+        
     authNotRequired.insert("GetVersion");
     authNotRequired.insert("GetAuthRequired");
     authNotRequired.insert("Authenticate");
@@ -2354,4 +2356,44 @@ void WSRequestHandler::HandleResetSceneItem(WSRequestHandler* req) {
     }
 
     obs_source_release(scene);
+}
+
+/**
+ * Get Source Data
+ *
+ * @param {String} `source-name` Name of the source item.
+ *
+ * @api requests
+ * @name GetSourceData
+ * @category sources
+ * @since ???
+ */
+void WSRequestHandler::HandleGetSourceData(WSRequestHandler* req) {
+
+    if (!req->hasField("source-name")) {
+        req->SendErrorResponse("missing request parameters");
+        return;
+    }    
+
+    const char* sourceName = obs_data_get_string(req->data, "source-name");
+    obs_source_t* source = obs_get_source_by_name(sourceName);
+
+    obs_data_t* data = obs_data_create();
+    obs_data_t* response = obs_data_create();
+
+    if (source) {
+        obs_data_set_string(response, "name",
+                            obs_source_get_name(source));
+        obs_data_set_double(response, "video_fps",
+                            obs_source_get_video_fps(source));
+        obs_data_set_double(response, "video_avg_fps",
+                            obs_source_get_video_avg_fps(source));
+        obs_data_set_double(response, "total_frames",
+                            obs_source_get_total_frames(source));
+        obs_data_set_int(response, "last_frame_ts",
+                            obs_source_get_last_frame_ts(source));
+    }    
+
+    req->SendOKResponse(response);
+    obs_data_release(response);
 }

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -121,6 +121,8 @@ class WSRequestHandler : public QObject {
     static void HandleGetTextGDIPlusProperties(WSRequestHandler* req);
     static void HandleSetBrowserSourceProperties(WSRequestHandler* req);
     static void HandleGetBrowserSourceProperties(WSRequestHandler* req);
+  
+    static void HandleGetSourceData(WSRequestHandler* req);
 };
 
 #endif // WSPROTOCOL_H


### PR DESCRIPTION
## Dear developers of OBS-Studio, OBS-Websocket and OBS-Websocket (python)

In this request I'd like to ask all three of you to consider approving
my merge requests for the following new feature in OBS-Studio/Websocket:

### Little background:

OBS-Studio/Websocket has great features for monitoring output streams 
and/or recordings but it lacks monitoring on its input streams. This is
for most users not a problem but for real-broadcast tasks this quickly
becomes an issue because input streams are not always reliable. If 
you're running a 24/7 task, OBS-Studio becomes unsuitable. Which is a 
shame I'd like to address in my code contributions/merge-requests. 

The patches (merge-requests) I wrote are three-fold hence I address all
three developer groups!

* OBS-Studio: 
	Pathed to keep a frame-counter for each produced frame by
	an input-source, keep an average-frame-per-second, and frame-per-second.
	Furthermore OBS-Studio is enabled to provide last-frame-time-stamp, 
	average-frame-per-second, frame-per-second, total-produced-frames-by-source-item
	information to 'third parties' e.g. obs-websocket.so
 
* OBS-Websocket (C++, Dependent on patch OBS-Studio):
	Pathed to be able to receive and answer queries for above mentioned information 
	and pass it to a web-socket client (e.g. obs-websocket python implementation)
	by source-name.

* OBS-Websocket (Python, Dependent on patch OBS-Websocket):
	Pathed to be able to query above mentioned information by source-name.

### Merge-requests links
https://github.com/Elektordi/obs-websocket-py/pull/11 (OBS-Websocket Python)
https://github.com/jp9000/obs-studio/pull/1053 (OBS-Studio)
https://github.com/Palakis/obs-websocket/pull/145 (OBS-Websocket C++)

### How to build?
```
CWD="`pwd`"
mkdir TEST && cd TEST
git clone --recursive https://github.com/masikh/obs-studio.git
cd obs-studio/plugins
git clone --recursive https://github.com/masikh/obs-websocket.git
cd ..
cmake .
make
echo "add_subdirectory(obs-websocket)" >> plugins/CMakeLists.txt
cmake -DLIBOBS_INCLUDE_DIR=${CWD}/TEST/obs-studio/libobs .
make && sudo make install
```

### How to use?

Paste below proof of concept code into a new (python) file. See comments in 
code below for setting up OBS for this example code and patching the python 
obs-websocket too!
```
#!/usr/bin/env python

# L.S.
#
# This proof of concept code will demonstrate the output
# of individual input source progress status. It expects
# that the obs-websocket is running on 'localhost:4444'
# with a password set to 'secret'. For ~this~ example to
# work you must configure a source in your scene-config
# named 'source-name'.
#
# This program expects that the requests.py (from obs-websocket)
# has the following class defined:
#
# class GetSourceData(base_classes.BaseRequest):
#     def __init__(self, source_name):
#         base_classes.BaseRequest.__init__(self)
#         self.name = "GetSourceData"
#         self.dataout["source-name"] = source_name
#
# Example output:
#
# run-time: 8207 name: source-name produced-frames: 117688 avg_fps: 14.00 fps: 24.39
# run-time: 8208 name: source-name produced-frames: 117715 avg_fps: 14.00 fps: 24.39
# run-time: 8209 name: source-name produced-frames: 117741 avg_fps: 14.00 fps: 24.39
#
# Note: Each source, also images, can be monitored. But
# only video sources are producing frames. Audio is not
# monitored, yet....)

import logging
import obswebsocket
from obswebsocket import requests

logging.basicConfig(level=logging.CRITICAL)


class OpenBroadcastServer:
    def __init__(self, host, port, password):
        self.host = host
        self.port = port
        self.password = password
        self.websocket = obswebsocket.obsws(self.host, self.port, self.password)
        self.connect()

    def connect(self):
        self.websocket.connect()

    def get_source_data(self, source_name):
        request = requests.GetSourceData(source_name)
        return self.websocket.call(request)


if __name__ == "__main__":
    from time import sleep
    obs = OpenBroadcastServer('localhost', 4444, 'secret')
    while True:
        result = obs.get_source_data('source-name')
        runtime = result.datain['last_frame_ts'] / 1000000000
        name = result.datain['name']
        produced_frames = int(result.datain['total_frames'])
        avg_fps = "{0:.2f}".format(result.datain['video_avg_fps'])
        fps = "{0:.2f}".format(result.datain['video_fps'])
        print "run-time: %s name: %s produced-frames: %s avg_fps: %s fps: %s" % (runtime,
                                                                                 name,
                                                                                 produced_frames,
                                                                                 avg_fps,
                                                                                 fps)
        sleep(1)


```