### PR TITLE
Automatic function-scope OBS instance release + refactor variable names to camelCase

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -19,6 +19,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <QString>
+
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 
@@ -29,11 +31,11 @@ class Config {
     void Load();
     void Save();
 
-    void SetPassword(const char* password);
-    bool CheckAuth(const char* userChallenge);
-    const char* GenerateSalt();
-    static const char* GenerateSecret(
-        const char* password, const char* salt);
+    void SetPassword(QString password);
+    bool CheckAuth(QString userChallenge);
+    QString GenerateSalt();
+    static QString GenerateSecret(
+        QString password, QString salt);
 
     bool ServerEnabled;
     uint64_t ServerPort;
@@ -42,9 +44,9 @@ class Config {
     bool AlertsEnabled;
 
     bool AuthRequired;
-    const char* Secret;
-    const char* Salt;
-    const char* SessionChallenge;
+    QString Secret;
+    QString Salt;
+    QString SessionChallenge;
     bool SettingsLoaded;
 
     static Config* Current();

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -163,8 +163,8 @@ bool Utils::IsValidAlignment(const uint32_t alignment) {
     return false;
 }
 
-obs_source_t* Utils::GetTransitionFromName(const char* search_name) {
-    obs_source_t* found_transition = NULL;
+obs_source_t* Utils::GetTransitionFromName(QString searchName) {
+    obs_source_t* foundTransition = nullptr;
 
     obs_frontend_source_list transition_list = {};
     obs_frontend_get_transitions(&transition_list);
@@ -509,7 +509,7 @@ void Utils::StartReplayBuffer() {
 }
 
 bool Utils::IsRPHotkeySet() {
-
+    OBSOutputAutoRelease rpOutput = obs_frontend_get_replay_buffer_output();
     OBSDataAutoRelease hotkeys = obs_hotkeys_save_output(rpOutput);
     OBSDataArrayAutoRelease bindings = obs_data_get_array(hotkeys,
         "ReplayBuffer.Save");

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -30,7 +30,7 @@ Q_DECLARE_METATYPE(OBSScene);
 
 const char* qstring_data_copy(QString value) {
     QByteArray stringData = value.toUtf8();
-    const char* constStringData = new const char[stringData.size()];
+    const char* constStringData = new const char[stringData.size()]();
     memcpy((void*)constStringData, stringData.constData(), stringData.size());
     return constStringData;
 }

--- a/Utils.h
+++ b/Utils.h
@@ -19,6 +19,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <stdio.h>
+
 #include <QSpinBox>
 #include <QPushButton>
 #include <QLayout>
@@ -26,21 +28,23 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QSystemTrayIcon>
 #include <QHostAddress>
 
-#include <stdio.h>
+#include <obs.hpp>
 #include <obs-module.h>
 #include <util/config-file.h>
 
+const char* qstring_data_copy(QString value);
+
 class Utils {
   public:
-    static obs_data_array_t* GetSceneItems(obs_source_t* source);
-    static obs_data_t* GetSceneItemData(obs_scene_item* item);
+    static obs_data_array_t* GetSceneItems(OBSSource source);
+    static obs_data_t* GetSceneItemData(OBSSceneItem item);
     static obs_sceneitem_t* GetSceneItemFromName(
-        obs_source_t* source, const char* name);
-    static obs_source_t* GetTransitionFromName(const char* search_name);
-    static obs_source_t* GetSceneFromNameOrCurrent(const char* scene_name);
+        OBSSource source, QString name);
+    static obs_source_t* GetTransitionFromName(QString transitionName);
+    static obs_source_t* GetSceneFromNameOrCurrent(QString sceneName);
 
     static obs_data_array_t* GetScenes();
-    static obs_data_t* GetSceneData(obs_source* source);
+    static obs_data_t* GetSceneData(OBSSource source);
 
     static obs_data_array_t* GetSceneCollections();
     static obs_data_array_t* GetProfiles();
@@ -49,7 +53,7 @@ class Utils {
     static int GetTransitionDuration();
     static void SetTransitionDuration(int ms);
 
-    static bool SetTransitionByName(const char* transition_name);
+    static bool SetTransitionByName(QString transitionName);
 
     static QPushButton* GetPreviewModeButtonControl();
     static QLayout* GetPreviewLayout();
@@ -70,8 +74,8 @@ class Utils {
     static const char* GetRecordingFolder();
     static bool SetRecordingFolder(const char* path);
 
-    static QString* ParseDataToQueryString(obs_data_t * data);
-    static obs_hotkey_t* FindHotkeyByName(const char* name);
+    static QString ParseDataToQueryString(OBSData data);
+    static obs_hotkey_t* FindHotkeyByName(QString name);
     static bool ReplayBufferEnabled();
     static bool RPHotkeySet();
 };

--- a/Utils.h
+++ b/Utils.h
@@ -36,15 +36,15 @@ const char* qstring_data_copy(QString value);
 
 class Utils {
   public:
-    static obs_data_array_t* GetSceneItems(OBSSource source);
-    static obs_data_t* GetSceneItemData(OBSSceneItem item);
+    static obs_data_array_t* GetSceneItems(obs_source_t* source);
+    static obs_data_t* GetSceneItemData(obs_sceneitem_t* item);
     static obs_sceneitem_t* GetSceneItemFromName(
-        OBSSource source, QString name);
+        obs_source_t* source, QString name);
     static obs_source_t* GetTransitionFromName(QString transitionName);
     static obs_source_t* GetSceneFromNameOrCurrent(QString sceneName);
 
     static obs_data_array_t* GetScenes();
-    static obs_data_t* GetSceneData(OBSSource source);
+    static obs_data_t* GetSceneData(obs_source_t* source);
 
     static obs_data_array_t* GetSceneCollections();
     static obs_data_array_t* GetProfiles();
@@ -74,7 +74,7 @@ class Utils {
     static const char* GetRecordingFolder();
     static bool SetRecordingFolder(const char* path);
 
-    static QString ParseDataToQueryString(OBSData data);
+    static QString ParseDataToQueryString(obs_data_t* data);
     static obs_hotkey_t* FindHotkeyByName(QString name);
     static bool ReplayBufferEnabled();
     static bool RPHotkeySet();

--- a/WSEvents.h
+++ b/WSEvents.h
@@ -33,8 +33,8 @@ class WSEvents : public QObject {
     static void FrontendEventHandler(
         enum obs_frontend_event event, void* privateData);
     static WSEvents* Instance;
-    void connectTransitionSignals(OBSSource transition);
-    void connectSceneSignals(OBSSource scene);
+    void connectTransitionSignals(obs_source_t* transition);
+    void connectSceneSignals(obs_source_t* scene);
 
     uint64_t GetStreamingTime();
     const char* GetStreamingTimecode();
@@ -68,7 +68,7 @@ class WSEvents : public QObject {
     uint64_t _lastBytesSentTime;
 
     void broadcastUpdate(const char* updateType,
-        OBSData additionalFields);
+        obs_data_t* additionalFields);
 
     void OnSceneChange();
     void OnSceneListChange();

--- a/WSEvents.h
+++ b/WSEvents.h
@@ -20,6 +20,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #ifndef WSEVENTS_H
 #define WSEVENTS_H
 
+#include <obs.hpp>
 #include <obs-frontend-api.h>
 #include <QListWidgetItem>
 #include "WSServer.h"
@@ -30,17 +31,17 @@ class WSEvents : public QObject {
     explicit WSEvents(WSServer* srv);
     ~WSEvents();
     static void FrontendEventHandler(
-        enum obs_frontend_event event, void* private_data);
+        enum obs_frontend_event event, void* privateData);
     static WSEvents* Instance;
-    void connectTransitionSignals(obs_source_t* transition);
-    void connectSceneSignals(obs_source_t* scene);
+    void connectTransitionSignals(OBSSource transition);
+    void connectSceneSignals(OBSSource scene);
 
     uint64_t GetStreamingTime();
     const char* GetStreamingTimecode();
     uint64_t GetRecordingTime();
     const char* GetRecordingTimecode();
 
-    bool Heartbeat_active;
+    bool HeartbeatIsActive;
 
   private slots:
     void deferredInitOperations();
@@ -52,22 +53,22 @@ class WSEvents : public QObject {
 
   private:
     WSServer* _srv;
-    signal_handler_t* transition_handler;
-    signal_handler_t* scene_handler;
+    signal_handler_t* transitionHandler;
+    signal_handler_t* sceneHandler;
 
     bool pulse;
 
-    bool _streaming_active;
-    bool _recording_active;
+    bool _streamingActive;
+    bool _recordingActive;
 
-    uint64_t _stream_starttime;
-    uint64_t _rec_starttime;
+    uint64_t _streamStarttime;
+    uint64_t _recStarttime;
 
     uint64_t _lastBytesSent;
     uint64_t _lastBytesSentTime;
 
     void broadcastUpdate(const char* updateType,
-        obs_data_t* additionalFields);
+        OBSData additionalFields);
 
     void OnSceneChange();
     void OnSceneListChange();

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -30,8 +30,6 @@
 
 #include "WSRequestHandler.h"
 
-OBSService WSRequestHandler::_service = nullptr;
-
 WSRequestHandler::WSRequestHandler(QWebSocket* client) :
     _messageId(0),
     _requestType(""),
@@ -1317,8 +1315,8 @@ void WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler* req) {
         return;
     }
 
-    const char* item_name = obs_data_get_string(req->data, "item");
-    if (!str_valid(item_name)) {
+    QString item_name = obs_data_get_string(req->data, "item");
+    if (item_name.isEmpty()) {
         req->SendErrorResponse("invalid request parameters");
         return;
     }
@@ -1339,7 +1337,7 @@ void WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler* req) {
 
     obs_data_t* data = obs_data_create();
 
-    obs_data_set_string(data, "name", item_name);
+    obs_data_set_string(data, "name", item_name.toUtf8());
 
     obs_data_t* pos_data = obs_data_create();
     vec2 pos;
@@ -1446,8 +1444,8 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
         return;
     }
 
-    const char* item_name = obs_data_get_string(req->data, "item");
-    if (!str_valid(item_name)) {
+    QString item_name = obs_data_get_string(req->data, "item");
+    if (item_name.isEmpty()) {
         req->SendErrorResponse("invalid request parameters");
         return;
     }

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -1337,7 +1337,6 @@ void WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler* req) {
         Utils::GetSceneItemFromName(scene, itemName);
     if (!sceneItem) {
         req->SendErrorResponse("specified scene item doesn't exist");
-        obs_source_release(scene);
         return;
     }
 
@@ -1464,7 +1463,6 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
         Utils::GetSceneItemFromName(scene, itemName);
     if (!sceneItem) {
         req->SendErrorResponse("specified scene item doesn't exist");
-        obs_source_release(scene);
         return;
     }
 

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -24,7 +24,6 @@
 #include <QString>
 
 #include "WSEvents.h"
-#include "obs-websocket.h"
 #include "Config.h"
 #include "Utils.h"
 

--- a/WSRequestHandler.cpp
+++ b/WSRequestHandler.cpp
@@ -189,7 +189,7 @@ void WSRequestHandler::SendErrorResponse(const char* errorMessage) {
 }
 
 void WSRequestHandler::SendErrorResponse(obs_data_t* additionalFields) {
-    obs_data_t* response = obs_data_create();
+    OBSDataAutoRelease response = obs_data_create();
     obs_data_set_string(response, "status", "error");
     obs_data_set_string(response, "message-id", _messageId);
 
@@ -548,7 +548,7 @@ void WSRequestHandler::HandleStartStreaming(WSRequestHandler* req) {
             OBSDataAutoRelease newSettings = obs_data_get_obj(streamData, "settings");
             OBSDataAutoRelease newMetadata = obs_data_get_obj(streamData, "metadata");
 
-            obs_data_t* csHotkeys =
+            OBSDataAutoRelease csHotkeys =
                 obs_hotkeys_save_service(configuredService);
 
             QString currentType = obs_service_get_type(configuredService);
@@ -1501,7 +1501,7 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
     if (req->hasField("scale")) {
         vec2 oldScale;
         obs_sceneitem_get_scale(sceneItem, &oldScale);
-        obs_data_t* reqScale = obs_data_get_obj(req->data, "scale");
+        OBSDataAutoRelease reqScale = obs_data_get_obj(req->data, "scale");
         vec2 newScale = oldScale;
         if (obs_data_has_user_value(reqScale, "x")) {
             newScale.x = obs_data_get_double(reqScale, "x");
@@ -1515,7 +1515,7 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
     if (req->hasField("crop")) {
         obs_sceneitem_crop oldCrop;
         obs_sceneitem_get_crop(sceneItem, &oldCrop);
-        obs_data_t* reqCrop = obs_data_get_obj(req->data, "crop");
+        OBSDataAutoRelease reqCrop = obs_data_get_obj(req->data, "crop");
         obs_sceneitem_crop newCrop = oldCrop;
         if (obs_data_has_user_value(reqCrop, "top")) {
             newCrop.top = obs_data_get_int(reqCrop, "top");
@@ -1538,8 +1538,8 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
 
     if (req->hasField("bounds")) {
         bool badBounds = false;
-        obs_data_t* boundsError = obs_data_create();
-        obs_data_t* reqBounds = obs_data_get_obj(req->data, "bounds");
+        OBSDataAutoRelease boundsError = obs_data_create();
+        OBSDataAutoRelease reqBounds = obs_data_get_obj(req->data, "bounds");
         if (obs_data_has_user_value(reqBounds, "type")) {
             const char* newBoundsType = obs_data_get_string(reqBounds, "type");
             if (newBoundsType == "OBS_BOUNDS_NONE") {

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -24,6 +24,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QWebSocket>
 #include <QWebSocketServer>
 
+#include <obs.hpp>
 #include <obs-frontend-api.h>
 
 class WSRequestHandler : public QObject {
@@ -33,21 +34,21 @@ class WSRequestHandler : public QObject {
     explicit WSRequestHandler(QWebSocket* client);
     ~WSRequestHandler();
     void processIncomingMessage(QString textMessage);
-    bool hasField(const char* name);
+    bool hasField(QString name);
 
   private:
-    static obs_service_t* _service;
+    static OBSService _service;
     QWebSocket* _client;
     const char* _messageId;
     const char* _requestType;
-    obs_data_t* data;
+    OBSData data;
 
     QHash<QString, void(*)(WSRequestHandler*)> messageMap;
     QSet<QString> authNotRequired;
 
-    void SendOKResponse(obs_data_t* additionalFields = NULL);
+    void SendOKResponse(OBSData additionalFields = NULL);
     void SendErrorResponse(const char* errorMessage);
-    void SendResponse(obs_data_t* response);
+    void SendResponse(OBSData response);
 
     static void HandleGetVersion(WSRequestHandler* req);
     static void HandleGetAuthRequired(WSRequestHandler* req);

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -46,9 +46,9 @@ class WSRequestHandler : public QObject {
     QHash<QString, void(*)(WSRequestHandler*)> messageMap;
     QSet<QString> authNotRequired;
 
-    void SendOKResponse(OBSData additionalFields = NULL);
+    void SendOKResponse(obs_data_t* additionalFields = NULL);
     void SendErrorResponse(const char* errorMessage);
-    void SendResponse(OBSData response);
+    void SendResponse(obs_data_t* response);
 
     static void HandleGetVersion(WSRequestHandler* req);
     static void HandleGetAuthRequired(WSRequestHandler* req);

--- a/WSRequestHandler.h
+++ b/WSRequestHandler.h
@@ -27,6 +27,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
 
+#include "obs-websocket.h"
+
 class WSRequestHandler : public QObject {
   Q_OBJECT
 
@@ -40,7 +42,7 @@ class WSRequestHandler : public QObject {
     QWebSocket* _client;
     const char* _messageId;
     const char* _requestType;
-    OBSData data;
+    OBSDataAutoRelease data;
 
     QHash<QString, void(*)(WSRequestHandler*)> messageMap;
     QSet<QString> authNotRequired;

--- a/forms/settings-dialog.cpp
+++ b/forms/settings-dialog.cpp
@@ -77,17 +77,12 @@ void SettingsDialog::FormAccepted() {
     conf->DebugEnabled = ui->debugEnabled->isChecked();
     conf->AlertsEnabled = ui->alertsEnabled->isChecked();
 
-    if (ui->authRequired->isChecked())
-    {
-        if (ui->password->text() != CHANGE_ME)
-        {
-            QByteArray pwd = ui->password->text().toUtf8();
-            const char *new_password = pwd;
-
-            conf->SetPassword(new_password);
+    if (ui->authRequired->isChecked()) {
+        if (ui->password->text() != CHANGE_ME) {
+            conf->SetPassword(ui->password->text());
         }
 
-        if (strcmp(Config::Current()->Secret, "") != 0)
+        if (!Config::Current()->Secret.isEmpty())
             conf->AuthRequired = true;
         else
             conf->AuthRequired = false;

--- a/obs-websocket.cpp
+++ b/obs-websocket.cpp
@@ -28,6 +28,12 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "Config.h"
 #include "forms/settings-dialog.h"
 
+void ___source_dummy_addref(obs_source_t*) {}
+void ___sceneitem_dummy_addref(obs_sceneitem_t*) {}
+void ___data_dummy_addref(obs_data_t*) {}
+void ___data_array_dummy_addref(obs_data_array_t*) {}
+void ___output_dummy_addref(obs_output_t*) {}
+
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-websocket", "en-US")
 

--- a/obs-websocket.h
+++ b/obs-websocket.h
@@ -19,6 +19,25 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #ifndef OBSWEBSOCKET_H
 #define OBSWEBSOCKET_H
 
+#include <obs.hpp>
+
+void ___source_dummy_addref(obs_source_t*);
+void ___sceneitem_dummy_addref(obs_sceneitem_t*);
+void ___data_dummy_addref(obs_data_t*);
+void ___data_array_dummy_addref(obs_data_array_t*);
+void ___output_dummy_addref(obs_output_t*);
+
+using OBSSourceAutoRelease =
+	OBSRef<obs_source_t*, ___source_dummy_addref, obs_source_release>;
+using OBSSceneItemAutoRelease =
+	OBSRef<obs_sceneitem_t*, ___sceneitem_dummy_addref, obs_sceneitem_release>;
+using OBSDataAutoRelease =
+	OBSRef<obs_data_t*, ___data_dummy_addref, obs_data_release>;
+using OBSDataArrayAutoRelease =
+	OBSRef<obs_data_array_t*, ___data_array_dummy_addref, obs_data_array_release>;
+using OBSOutputAutoRelease =
+	OBSRef<obs_output_t*, ___output_dummy_addref, obs_output_release>;
+
 #define PROP_AUTHENTICATED "wsclient_authenticated"
 #define OBS_WEBSOCKET_VERSION "4.2.1"
 


### PR DESCRIPTION
## Introduction
I've undergone a rewrite of some of obs-websocket's internals:
- Rewrite variable names to camelCase
- Use `obs_data_t*`, `obs_source_t*`, `obs_output_*` and others in special wrapper classes that automatically call their associated `release` function.

## Details
Current `release` code:
```cpp
void dummy() {
    obs_data_t* data_obj = obs_data_create();
    obs_data_set_string(data_obj, "key", "value);
    obs_data_release(data_obj);
}
```

New proposed `release` code:
```cpp
void dummy() {
    OBSDataAutoRelease dataObj = obs_data_create();
    obs_data_set_string(dataObj, "key", "value);
}
```

The goal of this rewrite is to unify code style, make easier the use of OBS' API and reduce the number of potential memory leaks. The auto-releases classes are named are based on `OBSRef` from libobs' C++ helpers in `obs.hpp`.

Note: `obs.hpp` already has classes that do automatic reference count management. However, because most libobs methods used in obs-websocket already call `addref` on the returned instance (hence increasing the reference count), using an OBSRef derivative results in a refcount offset up by one, potentially causing memory leaks.

Below is a comparison of current and new paradigms:

Current implementation:
```cpp
void dummy() {
    // obs_data_t* created. refcount = 1 
    obs_data_t* dataObj = obs_data_create();
    
    // obs_data_release decreases the refcount by one.
    // refcount is now 0 and instance can be destroyed.
    obs_data_release(dataObj);
}
```

Implemention using `obs.hpp`'s OBSRef derivatives 
```cpp
void dummy() {
    // obs_data_created. refcount = 1
    // OBSData captures the instance and calls addref() on it. refcount is now 2
    OBSData dataObj = obs_data_create();

    // End of function scope. dataObj is automatically destroyed.
    // OBSData's destructor calls release() on the instance, which decreases the refcount
    // by one. refcount is now 1, but the pointer is used only there and then the pointer will be lost
    // This causes a memory leak
}
```

Implemention using obs-websocket's OBS*AutoRelease derivatives of OBSRef 
```cpp
void dummy() {
    // obs_data_created. refcount = 1
    // OBSData captures the instance but doesn't call addref(). refcount is still 1.
    OBSDataAutoRelease dataObj = obs_data_create();

    // End of function scope. dataObj is automatically destroyed.
    // OBSData's destructor calls release() on the instance, which decreases the refcount
    // by one. refcount is now 0 and the instance is automatically destroyed. No memory leak.
}
```

This works fine with instances returned by most libobs methods. However, some don't addref on their result, and the only way to find out whether an OBSSource or OBSSourceAutoRelease should be used require digging through libobs's source code.
However, in most if not all cases, obs_data_t* instances should be used with OBSDataAutoRelease because most functions returning an obs_data_t* pointer call addref() before returning.

## Conclusion
I opened this as an internal PR because I'd like third-party reviews on some aspects:
- Is the new style easy enough to use and understand?
- Does it solves memory leaks in instances returned from libobs and easily avoids them when writing new code?