### PR TITLE
Create folder for 'SetRecordingFolder' if it does not exist

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -367,9 +367,8 @@ const char* Utils::GetRecordingFolder() {
 }
 
 bool Utils::SetRecordingFolder(const char* path) {
-    QDir dir(path);
-    if (!dir.exists())
-        dir.mkpath(".");
+    if (!QDir(path).exists())
+        return false;
 
     config_t* profile = obs_frontend_get_profile_config();
     QString outputMode = config_get_string(profile, "Output", "Mode");

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -367,8 +367,9 @@ const char* Utils::GetRecordingFolder() {
 }
 
 bool Utils::SetRecordingFolder(const char* path) {
-    if (!QDir(path).exists())
-        return false;
+    QDir dir(path);
+    if (!dir.exists())
+        dir.mkpath(".");
 
     config_t* profile = obs_frontend_get_profile_config();
     QString outputMode = config_get_string(profile, "Output", "Mode");


### PR DESCRIPTION
When using 'SetRecordingFolder', it will fail if the folder does not already exist. If one wants to save recordings to changing folders (such as a different folder for each game), this is not possible without running an extra program/script.

This pull request changes obs-websocket to try to create the directory (and all intermediaries) when using 'SetRecordingFolder' to solve this issue.