### PR TITLE
Workaround/fix for Control-Z in qstring_data_copy

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,11 +28,12 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 Q_DECLARE_METATYPE(OBSScene);
 
-const char* qstring_data_copy(QString value) {
+char* qstring_data_copy(QString value) {
     QByteArray stringData = value.toUtf8();
-    const char* constStringData = new const char[stringData.size()]();
-    memcpy((void*)constStringData, stringData.constData(), stringData.size());
-    return constStringData;
+    char* stringDataOut = new char[stringData.size()]();
+    memcpy((void*)stringDataOut, stringData.constData(), stringData.size());
+    stringDataOut[stringData.size()]=0;
+    return stringDataOut;
 }
 
 obs_data_array_t* Utils::StringListToArray(char** strings, char* key) {

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -32,7 +32,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-module.h>
 #include <util/config-file.h>
 
-const char* qstring_data_copy(QString value);
+char* qstring_data_copy(QString value);
 
 class Utils {
   public:


### PR DESCRIPTION
Changed const char * to char *

Perhaps not the BEST solution!? I am open to better!?

--Doug (dx9s)