### PR TITLE
fixing delete scene item response and setting sceneitem bounds

### DIFF
--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -271,7 +271,7 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
 		OBSDataAutoRelease boundsError = obs_data_create();
 		OBSDataAutoRelease reqBounds = obs_data_get_obj(reqItem, "bounds");
 		if (obs_data_has_user_value(reqBounds, "type")) {
-			const char* newBoundsType = obs_data_get_string(reqBounds, "type");
+			const QString newBoundsType = obs_data_get_string(reqBounds, "type");
 			if (newBoundsType == "OBS_BOUNDS_NONE") {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_NONE);
 			}

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1273,7 +1273,7 @@ void WSRequestHandler::HandleDuplicateSceneItem(WSRequestHandler* req) {
     obs_data_set_string(itemData, "name", obs_source_get_name(obs_sceneitem_get_source(newItem)));
     obs_data_set_obj(responseData, "item", itemData);
     obs_data_set_string(responseData, "scene", obs_source_get_name(toScene));
-    req->SendResponse(responseData);
+    req->SendOKResponse(responseData);
 }
 
 /**


### PR DESCRIPTION
`char*` to `QString` for string comparison == operator

`SendOKResponse` to send the object properly