### PR TITLE
CI(Windows): Use Visual Studio 2017

### DIFF
--- a/CI/install-setup-qt.cmd
+++ b/CI/install-setup-qt.cmd
@@ -2,5 +2,5 @@
 
 REM Set default values to use AppVeyor's built-in Qt.
 set QTDIR32=C:\Qt\5.10.1\msvc2015
-set QTDIR64=C:\Qt\5.10.1\msvc2015_64
+set QTDIR64=C:\Qt\5.10.1\msvc2017_64
 set QTCompileVersion=5.10.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2017
+
 environment:
   CURL_VERSION: 7.39.0
 
@@ -15,9 +17,9 @@ install:
   - mkdir build32
   - mkdir build64
   - cd ./build32
-  - cmake -G "Visual Studio 14 2015" -DQTDIR="%QTDIR32%" -DLibObs_DIR="C:\projects\obs-studio\build32\libobs" -DLIBOBS_INCLUDE_DIR="C:\projects\obs-studio\libobs" -DLIBOBS_LIB="C:\projects\obs-studio\build32\libobs\%build_config%\obs.lib" -DOBS_FRONTEND_LIB="C:\projects\obs-studio\build32\UI\obs-frontend-api\%build_config%\obs-frontend-api.lib" ..
+  - cmake -G "Visual Studio 15 2017" -DQTDIR="%QTDIR32%" -DLibObs_DIR="C:\projects\obs-studio\build32\libobs" -DLIBOBS_INCLUDE_DIR="C:\projects\obs-studio\libobs" -DLIBOBS_LIB="C:\projects\obs-studio\build32\libobs\%build_config%\obs.lib" -DOBS_FRONTEND_LIB="C:\projects\obs-studio\build32\UI\obs-frontend-api\%build_config%\obs-frontend-api.lib" ..
   - cd ../build64
-  - cmake -G "Visual Studio 14 2015 Win64" -DQTDIR="%QTDIR64%" -DLibObs_DIR="C:\projects\obs-studio\build64\libobs" -DLIBOBS_INCLUDE_DIR="C:\projects\obs-studio\libobs" -DLIBOBS_LIB="C:\projects\obs-studio\build64\libobs\%build_config%\obs.lib" -DOBS_FRONTEND_LIB="C:\projects\obs-studio\build64\UI\obs-frontend-api\%build_config%\obs-frontend-api.lib" ..
+  - cmake -G "Visual Studio 15 2017 Win64" -DQTDIR="%QTDIR64%" -DLibObs_DIR="C:\projects\obs-studio\build64\libobs" -DLIBOBS_INCLUDE_DIR="C:\projects\obs-studio\libobs" -DLIBOBS_LIB="C:\projects\obs-studio\build64\libobs\%build_config%\obs.lib" -DOBS_FRONTEND_LIB="C:\projects\obs-studio\build64\UI\obs-frontend-api\%build_config%\obs-frontend-api.lib" ..
 
 build_script:
   - call msbuild /m /p:Configuration=%build_config% C:\projects\obs-websocket\build32\obs-websocket.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
Official OBS releases have switched to Visual Studio 2017 and Qt 5.10.1. There is no 32-bit Qt 5.10.1 package for Visual Studio 2017, but the Visual Studio 2015 package is compatible.

The biggest thing required to do this on AppVeyor is to specify the Visual Studio 2017 image.  You can see from the CI results on my fork ([here](https://github.com/RytoEX/obs-websocket/commits/vs2017qt510), while it exists) or from the [AppVeyor build history](https://ci.appveyor.com/project/RytoEX/obs-websocket/build/1.0.51) that it builds correctly.