### PR TITLE
DuplicateSceneItem bug fix

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1219,13 +1219,13 @@ void WSRequestHandler::HandleDeleteSceneItem(WSRequestHandler* req) {
 
 struct DuplicateSceneItemData {
     obs_sceneitem_t *referenceItem;
-    obs_source_t *newSource;
+    obs_source_t *fromSource;
     obs_sceneitem_t *newItem;
 };
 
 static void DuplicateSceneItem(void *_data, obs_scene_t *scene) {
     DuplicateSceneItemData *data = (DuplicateSceneItemData *)_data;
-    data->newItem = obs_scene_add(scene, data->newSource);
+    data->newItem = obs_scene_add(scene, data->fromSource);
     obs_sceneitem_set_visible(data->newItem, obs_sceneitem_visible(data->referenceItem));
 }
 
@@ -1270,11 +1270,8 @@ void WSRequestHandler::HandleDuplicateSceneItem(WSRequestHandler* req) {
         return;
     }
 
-    OBSSourceAutoRelease fromSource = obs_sceneitem_get_source(referenceItem);
-    obs_source_t *newSource = obs_source_duplicate(fromSource, obs_source_get_name(fromSource), false);
-
     DuplicateSceneItemData data;
-    data.newSource = newSource;
+    data.fromSource = obs_sceneitem_get_source(referenceItem);
     data.referenceItem = referenceItem;
 
     obs_enter_graphics();


### PR DESCRIPTION
Pulled out duplication functionality to mirror [AddSource](https://github.com/obsproject/obs-studio/blob/868796e3a4e781ec8928547198fe3e47a6c4d716/UI/window-basic-source-select.cpp#L87) and added it into graphics context

Removed a AutoRelease that was unintentionally releasing sources more times than necessary and triggering crashes.

@Palakis Looking for feedback on fix and styling and want to test it a bit before merge. Will update if I am confident or find more issues.