### PR TITLE
CI and CMake improvements

### DIFF
--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -9,5 +9,6 @@ cmake .. \
   -DLIBOBS_INCLUDE_DIR=../../obs-studio/libobs \
   -DLIBOBS_LIB=../../obs-studio/libobs \
   -DOBS_FRONTEND_LIB="$(pwd)/../../obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=/usr \
 && make -j4

--- a/CI/install-build-obs.cmd
+++ b/CI/install-build-obs.cmd
@@ -60,7 +60,7 @@ REM If obs-studio directory does not exist, clone the git repo, get the latest
 REM tag number, and set the build flag.
 if not exist C:\projects\obs-studio (
   echo obs-studio directory does not exist
-  git clone --recursive https://github.com/jp9000/obs-studio
+  git clone https://github.com/jp9000/obs-studio
   cd C:\projects\obs-studio\
   git describe --tags --abbrev=0 > C:\projects\obs-studio-latest-tag.txt
   set /p OBSLatestTag=<C:\projects\obs-studio-latest-tag.txt

--- a/CI/install-build-obs.cmd
+++ b/CI/install-build-obs.cmd
@@ -60,7 +60,7 @@ REM If obs-studio directory does not exist, clone the git repo, get the latest
 REM tag number, and set the build flag.
 if not exist C:\projects\obs-studio (
   echo obs-studio directory does not exist
-  git clone https://github.com/jp9000/obs-studio
+  git clone https://github.com/obsproject/obs-studio
   cd C:\projects\obs-studio\
   git describe --tags --abbrev=0 > C:\projects\obs-studio-latest-tag.txt
   set /p OBSLatestTag=<C:\projects\obs-studio-latest-tag.txt

--- a/CI/install-build-obs.cmd
+++ b/CI/install-build-obs.cmd
@@ -67,6 +67,17 @@ if not exist C:\projects\obs-studio (
   set BuildOBS=true
 )
 
+REM If the needed obs-studio libs for this build_config do not exist,
+REM set the build flag.
+if not exist C:\projects\obs-studio\build32\libobs\%build_config%\obs.lib (
+  echo obs-studio\build32\libobs\%build_config%\obs.lib does not exist
+  set BuildOBS=true
+)
+if not exist C:\projects\obs-studio\build32\UI\obs-frontend-api\%build_config%\obs-frontend-api.lib (
+  echo obs-studio\build32\UI\obs-frontend-api\%build_config%\obs-frontend-api.lib does not exist
+  set BuildOBS=true
+)
+
 REM Some debug info
 echo:
 echo Latest tag pre-pull: %OBSLatestTagPrePull%

--- a/CI/install-build-obs.cmd
+++ b/CI/install-build-obs.cmd
@@ -97,12 +97,12 @@ if defined BuildOBS (
   mkdir build64
   echo   Running cmake for obs-studio %OBSLatestTag% 32-bit...
   cd ./build32
-  cmake -G "Visual Studio 15 2017" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
+  cmake -G "Visual Studio 15 2017" -DDISABLE_PLUGINS=true -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
   echo:
   echo:
   echo   Running cmake for obs-studio %OBSLatestTag% 64-bit...
   cd ../build64
-  cmake -G "Visual Studio 15 2017 Win64" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
+  cmake -G "Visual Studio 15 2017 Win64" -DDISABLE_PLUGINS=true -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
   echo:
   echo:
   echo   Building obs-studio %OBSLatestTag% 32-bit ^(Build Config: %build_config%^)...

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -22,6 +22,7 @@ cd obs-studio
 git checkout 21.0.0
 mkdir build && cd build
 cmake .. \
+  -DDISABLE_PLUGINS=true \
   -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake \
 && make -j4
 

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -17,7 +17,7 @@ brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2b121c9a96
 
 # Build obs-studio
 cd ..
-git clone --recursive https://github.com/jp9000/obs-studio
+git clone https://github.com/jp9000/obs-studio
 cd obs-studio
 git checkout 21.0.0
 mkdir build && cd build

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -17,7 +17,7 @@ brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2b121c9a96
 
 # Build obs-studio
 cd ..
-git clone https://github.com/jp9000/obs-studio
+git clone https://github.com/obsproject/obs-studio
 cd obs-studio
 git checkout 21.0.0
 mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,11 @@ if(WIN32)
 			"${QTDIR}/bin/Qt5Network.dll"
 			"${CMAKE_BINARY_DIR}/$<CONFIG>")
 
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
+			"${QTDIR}/bin/Qt5WebSockets.dll"
+			"${QTDIR}/bin/Qt5Network.dll"
+			"${CMAKE_BINARY_DIR}/$<CONFIG>")
+
 		COMMAND if $<CONFIG:Debug>==1 ("${CMAKE_COMMAND}" -E copy
 			"${QTDIR}/bin/Qt5WebSocketsd.dll"
 			"${QTDIR}/bin/Qt5Networkd.dll"
@@ -110,6 +115,7 @@ if(WIN32)
 	set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
 
 	add_custom_command(TARGET obs-websocket POST_BUILD
+		# If config is Release, package release files
 		COMMAND if $<CONFIG:Release>==1 (
 			"${CMAKE_COMMAND}" -E make_directory
 			"${RELEASE_DIR}/data/obs-plugins/obs-websocket"
@@ -123,6 +129,26 @@ if(WIN32)
 			"$<TARGET_FILE:obs-websocket>"
 			"${QTDIR}/bin/Qt5WebSockets.dll"
 			"${QTDIR}/bin/Qt5Network.dll"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		# If config is RelWithDebInfo, package release files
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 (
+			"${CMAKE_COMMAND}" -E make_directory
+			"${RELEASE_DIR}/data/obs-plugins/obs-websocket"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy_directory
+			"${PROJECT_SOURCE_DIR}/data"
+			"${RELEASE_DIR}/data/obs-plugins/obs-websocket")
+
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
+			"$<TARGET_FILE:obs-websocket>"
+			"${QTDIR}/bin/Qt5WebSockets.dll"
+			"${QTDIR}/bin/Qt5Network.dll"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
+			"$<TARGET_PDB_FILE:obs-websocket>"
 			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
 
 		# Copy to obs-studio dev environment for immediate testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,11 @@ if(WIN32)
 				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/obs-plugins/${ARCH_NAME}")
 
 		COMMAND if $<CONFIG:Debug>==1 (
+			"${CMAKE_COMMAND}" -E copy
+				"$<TARGET_PDB_FILE:obs-websocket>"
+				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:Debug>==1 (
 			"${CMAKE_COMMAND}" -E make_directory
 				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/data/obs-plugins/obs-websocket")
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - set DepsPath32=%CD%\dependencies2015\win32
   - set DepsPath64=%CD%\dependencies2015\win64
   - call C:\projects\obs-websocket\CI\install-setup-qt.cmd
-  - set build_config=Release
+  - set build_config=RelWithDebInfo
   - call C:\projects\obs-websocket\CI\install-build-obs.cmd
   - cd C:\projects\obs-websocket\
   - mkdir build32


### PR DESCRIPTION
This PR is a series of general CI and CMake improvements.

This PR adds support for the build config/type "RelWithDebInfo", which is what OBS uses for its official releases, and it sets the default build config to that.  This PR has also shown a reduction in CI build times of 1-5 minutes depending on CI service, CI status/availability, and whether a full OBS build is needed.

I still have some macOS specific CI/CMake changes I'd like to work on, but I figured I'd submit these first, so this PR can be considered separately from those later changes.  These changes build locally and on CI, and obs-websocket seems to work when run through some simple tests with the t2t2 web client.