### PR TITLE
macOS CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ matrix:
   - os: osx
     env: _macos_build
     osx_image: xcode8.3
-    before_install: "./CI/install-dependencies-macos.sh"
+    before_install:
+    - "./CI/install-dependencies-macos.sh"
+    - "./CI/install-build-obs-macos.sh"
     script: "./CI/build-macos.sh"
     after_success: 
     - ./CI/package-macos.sh

--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -ex
+
+# Build obs-studio
+cd ..
+git clone https://github.com/obsproject/obs-studio
+cd obs-studio
+OBSLatestTag=$(git describe --tags --abbrev=0)
+git checkout $OBSLatestTag
+mkdir build && cd build
+cmake .. \
+  -DDISABLE_PLUGINS=true \
+  -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake \
+&& make -j4

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -8,10 +8,7 @@ brew install libav
 
 # qtwebsockets deps
 # qt latest
-#brew install qt5
-
-# qt 5.9.2
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2b121c9a96e58a5da14228630cb71d5bead7137e/Formula/qt.rb
+brew install qt5
 
 #echo "Qt path: $(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
 

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -30,4 +30,4 @@ cmake .. \
 cd ..
 curl -L -O  http://s.sudre.free.fr/Software/files/Packages.dmg -f --retry 5 -C -
 hdiutil attach ./Packages.dmg
-sudo installer -pkg /Volumes/Packages\ 1.2.2/packages/Packages.pkg -target /
+sudo installer -pkg /Volumes/Packages\ 1.2.3/packages/Packages.pkg -target /

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -10,10 +10,6 @@ brew install libav
 # qt latest
 brew install qt5
 
-#echo "Qt path: $(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
-
-
 # Packages app
-curl -L -O  http://s.sudre.free.fr/Software/files/Packages.dmg -f --retry 5 -C -
-hdiutil attach ./Packages.dmg
-sudo installer -pkg /Volumes/Packages\ 1.2.3/packages/Packages.pkg -target /
+wget --quiet --retry-connrefused --waitretry=1 https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
+sudo installer -pkg ./Packages.pkg -target /

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -12,19 +12,8 @@ brew install qt5
 
 #echo "Qt path: $(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
 
-# Build obs-studio
-cd ..
-git clone https://github.com/obsproject/obs-studio
-cd obs-studio
-git checkout 21.0.0
-mkdir build && cd build
-cmake .. \
-  -DDISABLE_PLUGINS=true \
-  -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake \
-&& make -j4
 
 # Packages app
-cd ..
 curl -L -O  http://s.sudre.free.fr/Software/files/Packages.dmg -f --retry 5 -C -
 hdiutil attach ./Packages.dmg
 sudo installer -pkg /Volumes/Packages\ 1.2.3/packages/Packages.pkg -target /


### PR DESCRIPTION
This PR does several things:
* Update Packages to 1.2.3 to keep CI running correctly
* Update Qt to latest in brew (this is what OBS Studio CI does)
* Build the most recent OBS Studio git tag (as of this date 21.1.1)
* Move the obs-studio build task to a separate script (creates a separate section in CI logs, and lets user skip the obs-studio build script if building locally with scripts)

I have more macOS CI changes in the pipeline, but I'm struggling with a few of them, so I thought I'd split these off since they seem stable.

The obs-studio build script could probably use a bit of directory/path checking to make sure it's changing into the correct directory, but that should only be a concern if using the scripts locally, and I don't have access to a Mac to test locally.

On the note of keeping up with Packages updates, I did notice that obs-studio does something different with that [here](https://github.com/obsproject/obs-studio/blob/3040ff6347d006e52c90b5be365cae7a04aa07d6/CI/install-dependencies-osx.sh#L12).  Is this something that could be done here, or is Packages handled differently here for a reason?