### PR TITLE
Build instruction update

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
 # Compiling obs-websocket
 ## Prerequisites
-You'll need [QT 5.9.0](https://download.qt.io/official_releases/qt/5.7/5.7.0/), CMake, and a working development environment for OBS Studio installed on your computer. 
+You'll need [Qt 5.10.x](https://download.qt.io/official_releases/qt/5.10/), [CMake](https://cmake.org/download/), and a working [development environment for OBS Studio](https://obsproject.com/wiki/install-instructions) installed on your computer.
 
 ## Windows
 In cmake-gui, you'll have to set the following variables :
@@ -22,12 +22,13 @@ sudo make install
 ```
 
 ## OS X
-Use of the Travis macOS CI scripts is recommended. Please note that these scripts install new software and can change several settings on your system. An existing obs-studio development environment is not required, as `install-dependencies-macos.sh` will install it for you.
+Use of the Travis macOS CI scripts is recommended. Please note that these scripts install new software and can change several settings on your system. An existing obs-studio development environment is not required, as `install-build-obs-macos.sh` will install it for you.  If you already have a working obs-studio development environment and have built obs-studio, you can skip that script.
 Of course, you're encouraged to dig through the contents of these scripts to look for issues or specificities.
 ```
 git clone --recursive https://github.com/Palakis/obs-websocket.git
 cd obs-websocket
 ./CI/install-dependencies-macos.sh
+./CI/install-build-obs-macos.sh
 ./CI/build-macos.sh
 ./CI/package-macos.sh
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,9 @@
 # Compiling obs-websocket
 ## Prerequisites
-You'll need [Qt 5.10.x](https://download.qt.io/official_releases/qt/5.10/), [CMake](https://cmake.org/download/), and a working [development environment for OBS Studio](https://obsproject.com/wiki/install-instructions) installed on your computer.
+You'll need [Qt 5.10.x](https://download.qt.io/official_releases/qt/5.10/),
+[CMake](https://cmake.org/download/), and a working [development environment for
+OBS Studio](https://obsproject.com/wiki/install-instructions) installed on your
+computer.
 
 ## Windows
 In cmake-gui, you'll have to set the following variables :
@@ -22,8 +25,15 @@ sudo make install
 ```
 
 ## OS X
-Use of the Travis macOS CI scripts is recommended. Please note that these scripts install new software and can change several settings on your system. An existing obs-studio development environment is not required, as `install-build-obs-macos.sh` will install it for you.  If you already have a working obs-studio development environment and have built obs-studio, you can skip that script.
-Of course, you're encouraged to dig through the contents of these scripts to look for issues or specificities.
+Use of the Travis macOS CI scripts is recommended. Please note that these
+scripts install new software and can change several settings on your system. An
+existing obs-studio development environment is not required, as
+`install-build-obs-macos.sh` will install it for you. If you already have a
+working obs-studio development environment and have built obs-studio, you can
+skip that script.
+
+Of course, you're encouraged to dig through the contents of these scripts to
+look for issues or specificities.
 ```
 git clone --recursive https://github.com/Palakis/obs-websocket.git
 cd obs-websocket


### PR DESCRIPTION
This PR updates the building instructions to account for the newer Qt version, adds some links for convenience.  There is a second commit which wraps some longer lines to 80 characters to make it easier to read them in text editors.  I only included it as a separate commit to make it easier to see the actual content changes in the first commit, but these are intended to be squashed together (assuming that the word-wrapping is preferred/wanted at all).

It might be helpful to include a note that the Qt version should match what obs-studio uses, I just wasn't sure how to phrase it and where to put it.