### PR TITLE
MacOS Build fixes

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -22,6 +22,8 @@ sudo make install
 ```
 
 ## OS X
+As a prerequisite, you will need Xcode for your current OSX version, the command line tools, and [Homebrew](https://brew.sh/).
+Homebrew's setup will guide you in getting your system set up, you should be good to go once Homebrew is successfully up and running.
 Use of the Travis macOS CI scripts is recommended. Please note that these scripts install new software and can change several settings on your system. An existing obs-studio development environment is not required, as `install-dependencies-macos.sh` will install it for you.
 Of course, you're encouraged to dig through the contents of these scripts to look for issues or specificities.
 ```

--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -3,7 +3,7 @@ set -ex
 
 #export QT_PREFIX="$(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
 
-mkdir build && cd build
+mkdir -p build && cd build
 cmake .. \
   -DQTDIR=/usr/local/opt/qt \
   -DLIBOBS_INCLUDE_DIR=../../obs-studio/libobs \

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "-- Preparing package build"
-export QT_CELLAR_PREFIX="$(find /usr/local/Cellar/qt -d 1 | tail -n 1)"
+export QT_CELLAR_PREFIX="$(find /usr/local/Cellar/qt -d 1 | sort -t '.' -k 1,1n -k 2,2n -k 3,3n | tail -n 1)"
 
 export WS_LIB="/usr/local/opt/qt/lib/QtWebSockets.framework/QtWebSockets"
 export NET_LIB="/usr/local/opt/qt/lib/QtNetwork.framework/QtNetwork"

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -21,8 +21,8 @@ export FILENAME="obs-websocket-$VERSION.pkg"
 export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
 echo "-- Copying Qt dependencies"
-cp $WS_LIB ./build
-cp $NET_LIB ./build
+if [ ! -f ./build/$(basename $WS_LIB) ]; then cp $WS_LIB ./build; fi
+if [ ! -f ./build/$(basename $NET_LIB) ]; then cp $NET_LIB ./build; fi
 
 chmod +rw ./build/QtWebSockets ./build/QtNetwork
 

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -28,12 +28,14 @@ chmod +rw ./build/QtWebSockets ./build/QtNetwork
 
 echo "-- Modifying QtNetwork"
 install_name_tool \
+	-id @rpath/QtNetwork \
 	-change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork @rpath/QtNetwork \
 	-change $QT_CELLAR_PREFIX/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \
 	./build/QtNetwork
 
 echo "-- Modifying QtWebSockets"
 install_name_tool \
+	-id @rpath/QtWebSockets \
 	-change /usr/local/opt/qt/lib/QtWebSockets.framework/Versions/5/QtWebSockets @rpath/QtWebSockets \
 	-change $QT_CELLAR_PREFIX/lib/QtNetwork.framework/Versions/5/QtNetwork @rpath/QtNetwork \
 	-change $QT_CELLAR_PREFIX/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ endif()
 if(APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fvisibility=default")
 
+	set(CMAKE_SKIP_RPATH TRUE)
 	set_target_properties(obs-websocket PROPERTIES PREFIX "")
 	target_link_libraries(obs-websocket "${OBS_FRONTEND_LIB}")
 endif()


### PR DESCRIPTION
This PR adds some fixes mostly meant for people that build obs-websocket themselves using the CI scripts, which boil down to "don't fail when running the script a second time because the first try failed".

Included are some minor cleanups for `dyld` runtime path handling, making sure no build environment path artifacts are baked into the binaries produced. The current behavour may screw library loading up for people that happen to have something installed in the same paths as the travis environment, which basically boils down to having Qt 5.10.1 installed via homebrew (whether or not this is due to building obs-websocket yourself).

I tried to make the commit messages as explanatory as possble. If you have any further comments please let me know.