### PR TITLE
Can add and remove video sources

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -24,194 +24,199 @@
 
 #include "WSRequestHandler.h"
 
-QHash<QString, void(*)(WSRequestHandler*)> WSRequestHandler::messageMap {
-    { "GetVersion", WSRequestHandler::HandleGetVersion },
-    { "GetAuthRequired", WSRequestHandler::HandleGetAuthRequired },
-    { "Authenticate", WSRequestHandler::HandleAuthenticate },
+QHash<QString, void(*)(WSRequestHandler*)> WSRequestHandler::messageMap{
+	{ "GetVersion", WSRequestHandler::HandleGetVersion },
+	{ "GetAuthRequired", WSRequestHandler::HandleGetAuthRequired },
+	{ "Authenticate", WSRequestHandler::HandleAuthenticate },
 
-    { "SetHeartbeat", WSRequestHandler::HandleSetHeartbeat },
+	{ "SetHeartbeat", WSRequestHandler::HandleSetHeartbeat },
 
-    { "SetFilenameFormatting", WSRequestHandler::HandleSetFilenameFormatting },
-    { "GetFilenameFormatting", WSRequestHandler::HandleGetFilenameFormatting },
+	{ "SetFilenameFormatting", WSRequestHandler::HandleSetFilenameFormatting },
+	{ "GetFilenameFormatting", WSRequestHandler::HandleGetFilenameFormatting },
 
-    { "SetCurrentScene", WSRequestHandler::HandleSetCurrentScene },
-    { "GetCurrentScene", WSRequestHandler::HandleGetCurrentScene },
-    { "GetSceneList", WSRequestHandler::HandleGetSceneList },
+	{ "SetCurrentScene", WSRequestHandler::HandleSetCurrentScene },
+	{ "GetCurrentScene", WSRequestHandler::HandleGetCurrentScene },
+	{ "GetSceneList", WSRequestHandler::HandleGetSceneList },
 
-    { "SetSourceRender", WSRequestHandler::HandleSetSceneItemRender }, // Retrocompat
-    { "SetSceneItemRender", WSRequestHandler::HandleSetSceneItemRender },
-    { "SetSceneItemPosition", WSRequestHandler::HandleSetSceneItemPosition },
-    { "SetSceneItemTransform", WSRequestHandler::HandleSetSceneItemTransform },
-    { "SetSceneItemCrop", WSRequestHandler::HandleSetSceneItemCrop },
-    { "GetSceneItemProperties", WSRequestHandler::HandleGetSceneItemProperties },
-    { "SetSceneItemProperties", WSRequestHandler::HandleSetSceneItemProperties },
-    { "ResetSceneItem", WSRequestHandler::HandleResetSceneItem },
+	{ "SetSourceRender", WSRequestHandler::HandleSetSceneItemRender }, // Retrocompat
+	{ "SetSceneItemRender", WSRequestHandler::HandleSetSceneItemRender },
+	{ "SetSceneItemPosition", WSRequestHandler::HandleSetSceneItemPosition },
+	{ "SetSceneItemTransform", WSRequestHandler::HandleSetSceneItemTransform },
+	{ "SetSceneItemCrop", WSRequestHandler::HandleSetSceneItemCrop },
+	{ "GetSceneItemProperties", WSRequestHandler::HandleGetSceneItemProperties },
+	{ "SetSceneItemProperties", WSRequestHandler::HandleSetSceneItemProperties },
+	{ "ResetSceneItem", WSRequestHandler::HandleResetSceneItem },
 
-    { "GetStreamingStatus", WSRequestHandler::HandleGetStreamingStatus },
-    { "StartStopStreaming", WSRequestHandler::HandleStartStopStreaming },
-    { "StartStopRecording", WSRequestHandler::HandleStartStopRecording },
-    { "StartStreaming", WSRequestHandler::HandleStartStreaming },
-    { "StopStreaming", WSRequestHandler::HandleStopStreaming },
-    { "StartRecording", WSRequestHandler::HandleStartRecording },
-    { "StopRecording", WSRequestHandler::HandleStopRecording },
+	{ "GetStreamingStatus", WSRequestHandler::HandleGetStreamingStatus },
+	{ "StartStopStreaming", WSRequestHandler::HandleStartStopStreaming },
+	{ "StartStopRecording", WSRequestHandler::HandleStartStopRecording },
+	{ "StartStreaming", WSRequestHandler::HandleStartStreaming },
+	{ "StopStreaming", WSRequestHandler::HandleStopStreaming },
+	{ "StartRecording", WSRequestHandler::HandleStartRecording },
+	{ "StopRecording", WSRequestHandler::HandleStopRecording },
 
-    { "StartStopReplayBuffer", WSRequestHandler::HandleStartStopReplayBuffer },
-    { "StartReplayBuffer", WSRequestHandler::HandleStartReplayBuffer },
-    { "StopReplayBuffer", WSRequestHandler::HandleStopReplayBuffer },
-    { "SaveReplayBuffer", WSRequestHandler::HandleSaveReplayBuffer },
+	{ "StartStopReplayBuffer", WSRequestHandler::HandleStartStopReplayBuffer },
+	{ "StartReplayBuffer", WSRequestHandler::HandleStartReplayBuffer },
+	{ "StopReplayBuffer", WSRequestHandler::HandleStopReplayBuffer },
+	{ "SaveReplayBuffer", WSRequestHandler::HandleSaveReplayBuffer },
 
-    { "SetRecordingFolder", WSRequestHandler::HandleSetRecordingFolder },
-    { "GetRecordingFolder", WSRequestHandler::HandleGetRecordingFolder },
+	{ "SetRecordingFolder", WSRequestHandler::HandleSetRecordingFolder },
+	{ "GetRecordingFolder", WSRequestHandler::HandleGetRecordingFolder },
 
-    { "GetTransitionList", WSRequestHandler::HandleGetTransitionList },
-    { "GetCurrentTransition", WSRequestHandler::HandleGetCurrentTransition },
-    { "SetCurrentTransition", WSRequestHandler::HandleSetCurrentTransition },
-    { "SetTransitionDuration", WSRequestHandler::HandleSetTransitionDuration },
-    { "GetTransitionDuration", WSRequestHandler::HandleGetTransitionDuration },
+	{ "GetTransitionList", WSRequestHandler::HandleGetTransitionList },
+	{ "GetCurrentTransition", WSRequestHandler::HandleGetCurrentTransition },
+	{ "SetCurrentTransition", WSRequestHandler::HandleSetCurrentTransition },
+	{ "SetTransitionDuration", WSRequestHandler::HandleSetTransitionDuration },
+	{ "GetTransitionDuration", WSRequestHandler::HandleGetTransitionDuration },
 
-    { "SetVolume", WSRequestHandler::HandleSetVolume },
-    { "GetVolume", WSRequestHandler::HandleGetVolume },
-    { "ToggleMute", WSRequestHandler::HandleToggleMute },
-    { "SetMute", WSRequestHandler::HandleSetMute },
-    { "GetMute", WSRequestHandler::HandleGetMute },
-    { "SetSyncOffset", WSRequestHandler::HandleSetSyncOffset },
-    { "GetSyncOffset", WSRequestHandler::HandleGetSyncOffset },
-    { "GetSpecialSources", WSRequestHandler::HandleGetSpecialSources },
-    { "GetSourcesList", WSRequestHandler::HandleGetSourcesList },
-    { "GetSourceTypesList", WSRequestHandler::HandleGetSourceTypesList },
-    { "GetSourceSettings", WSRequestHandler::HandleGetSourceSettings },
-    { "SetSourceSettings", WSRequestHandler::HandleSetSourceSettings },
+	{ "SetVolume", WSRequestHandler::HandleSetVolume },
+	{ "GetVolume", WSRequestHandler::HandleGetVolume },
+	{ "ToggleMute", WSRequestHandler::HandleToggleMute },
+	{ "SetMute", WSRequestHandler::HandleSetMute },
+	{ "GetMute", WSRequestHandler::HandleGetMute },
+	{ "SetSyncOffset", WSRequestHandler::HandleSetSyncOffset },
+	{ "GetSyncOffset", WSRequestHandler::HandleGetSyncOffset },
+	{ "GetSpecialSources", WSRequestHandler::HandleGetSpecialSources },
+	{ "GetSourcesList", WSRequestHandler::HandleGetSourcesList },
+	{ "GetSourceTypesList", WSRequestHandler::HandleGetSourceTypesList },
+	{ "GetSourceSettings", WSRequestHandler::HandleGetSourceSettings },
+	{ "SetSourceSettings", WSRequestHandler::HandleSetSourceSettings },
 
-    { "SetCurrentSceneCollection", WSRequestHandler::HandleSetCurrentSceneCollection },
-    { "GetCurrentSceneCollection", WSRequestHandler::HandleGetCurrentSceneCollection },
-    { "ListSceneCollections", WSRequestHandler::HandleListSceneCollections },
+	{ "SetCurrentSceneCollection", WSRequestHandler::HandleSetCurrentSceneCollection },
+	{ "GetCurrentSceneCollection", WSRequestHandler::HandleGetCurrentSceneCollection },
+	{ "ListSceneCollections", WSRequestHandler::HandleListSceneCollections },
 
-    { "SetCurrentProfile", WSRequestHandler::HandleSetCurrentProfile },
-    { "GetCurrentProfile", WSRequestHandler::HandleGetCurrentProfile },
-    { "ListProfiles", WSRequestHandler::HandleListProfiles },
+	{ "SetCurrentProfile", WSRequestHandler::HandleSetCurrentProfile },
+	{ "GetCurrentProfile", WSRequestHandler::HandleGetCurrentProfile },
+	{ "ListProfiles", WSRequestHandler::HandleListProfiles },
 
-    { "SetStreamSettings", WSRequestHandler::HandleSetStreamSettings },
-    { "GetStreamSettings", WSRequestHandler::HandleGetStreamSettings },
-    { "SaveStreamSettings", WSRequestHandler::HandleSaveStreamSettings },
+	{ "SetStreamSettings", WSRequestHandler::HandleSetStreamSettings },
+	{ "GetStreamSettings", WSRequestHandler::HandleGetStreamSettings },
+	{ "SaveStreamSettings", WSRequestHandler::HandleSaveStreamSettings },
 
-    { "GetStudioModeStatus", WSRequestHandler::HandleGetStudioModeStatus },
-    { "GetPreviewScene", WSRequestHandler::HandleGetPreviewScene },
-    { "SetPreviewScene", WSRequestHandler::HandleSetPreviewScene },
-    { "TransitionToProgram", WSRequestHandler::HandleTransitionToProgram },
-    { "EnableStudioMode", WSRequestHandler::HandleEnableStudioMode },
-    { "DisableStudioMode", WSRequestHandler::HandleDisableStudioMode },
-    { "ToggleStudioMode", WSRequestHandler::HandleToggleStudioMode },
+	{ "GetStudioModeStatus", WSRequestHandler::HandleGetStudioModeStatus },
+	{ "GetPreviewScene", WSRequestHandler::HandleGetPreviewScene },
+	{ "SetPreviewScene", WSRequestHandler::HandleSetPreviewScene },
+	{ "TransitionToProgram", WSRequestHandler::HandleTransitionToProgram },
+	{ "EnableStudioMode", WSRequestHandler::HandleEnableStudioMode },
+	{ "DisableStudioMode", WSRequestHandler::HandleDisableStudioMode },
+	{ "ToggleStudioMode", WSRequestHandler::HandleToggleStudioMode },
 
-    { "SetTextGDIPlusProperties", WSRequestHandler::HandleSetTextGDIPlusProperties },
-    { "GetTextGDIPlusProperties", WSRequestHandler::HandleGetTextGDIPlusProperties },
+	{ "SetTextGDIPlusProperties", WSRequestHandler::HandleSetTextGDIPlusProperties },
+	{ "GetTextGDIPlusProperties", WSRequestHandler::HandleGetTextGDIPlusProperties },
 
-    { "GetBrowserSourceProperties", WSRequestHandler::HandleGetBrowserSourceProperties },
-    { "SetBrowserSourceProperties", WSRequestHandler::HandleSetBrowserSourceProperties }
+	{ "GetBrowserSourceProperties", WSRequestHandler::HandleGetBrowserSourceProperties },
+	{ "SetBrowserSourceProperties", WSRequestHandler::HandleSetBrowserSourceProperties },
+
+	{ "GetSourceTypeDefaults",WSRequestHandler::HandleGetSourceTypeDefaults },
+	{ "AddNewSourceToScene",WSRequestHandler::HandleAddNewSourceToScene },
+	{ "RemoveSourceFromScene",WSRequestHandler::HandleRemoveSourceFromScene }
+
 };
 
-QSet<QString> WSRequestHandler::authNotRequired {
-    "GetVersion",
-    "GetAuthRequired",
-    "Authenticate"
+QSet<QString> WSRequestHandler::authNotRequired{
+	"GetVersion",
+	"GetAuthRequired",
+	"Authenticate"
 };
 
 WSRequestHandler::WSRequestHandler(QWebSocket* client) :
-    _messageId(0),
-    _requestType(""),
-    data(nullptr),
-    _client(client)
+	_messageId(0),
+	_requestType(""),
+	data(nullptr),
+	_client(client)
 {
 }
 
 void WSRequestHandler::processIncomingMessage(QString textMessage) {
-    QByteArray msgData = textMessage.toUtf8();
-    const char* msg = msgData.constData();
+	QByteArray msgData = textMessage.toUtf8();
+	const char* msg = msgData.constData();
 
-    data = obs_data_create_from_json(msg);
-    if (!data) {
-        if (!msg)
-            msg = "<null pointer>";
+	data = obs_data_create_from_json(msg);
+	if (!data) {
+		if (!msg)
+			msg = "<null pointer>";
 
-        blog(LOG_ERROR, "invalid JSON payload received for '%s'", msg);
-        SendErrorResponse("invalid JSON payload");
-        return;
-    }
+		blog(LOG_ERROR, "invalid JSON payload received for '%s'", msg);
+		SendErrorResponse("invalid JSON payload");
+		return;
+	}
 
-    if (Config::Current()->DebugEnabled) {
-        blog(LOG_DEBUG, "Request >> '%s'", msg);
-    }
+	if (Config::Current()->DebugEnabled) {
+		blog(LOG_DEBUG, "Request >> '%s'", msg);
+	}
 
-    if (!hasField("request-type")
-        || !hasField("message-id"))
-    {
-        SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!hasField("request-type")
+		|| !hasField("message-id"))
+	{
+		SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    _requestType = obs_data_get_string(data, "request-type");
-    _messageId = obs_data_get_string(data, "message-id");
+	_requestType = obs_data_get_string(data, "request-type");
+	_messageId = obs_data_get_string(data, "message-id");
 
-    if (Config::Current()->AuthRequired
-        && (_client->property(PROP_AUTHENTICATED).toBool() == false)
-        && (authNotRequired.find(_requestType) == authNotRequired.end()))
-    {
-        SendErrorResponse("Not Authenticated");
-        return;
-    }
+	if (Config::Current()->AuthRequired
+		&& (_client->property(PROP_AUTHENTICATED).toBool() == false)
+		&& (authNotRequired.find(_requestType) == authNotRequired.end()))
+	{
+		SendErrorResponse("Not Authenticated");
+		return;
+	}
 
-    void (*handlerFunc)(WSRequestHandler*) = (messageMap[_requestType]);
+	void(*handlerFunc)(WSRequestHandler*) = (messageMap[_requestType]);
 
-    if (handlerFunc != nullptr)
-        handlerFunc(this);
-    else
-        SendErrorResponse("invalid request type");
+	if (handlerFunc != nullptr)
+		handlerFunc(this);
+	else
+		SendErrorResponse("invalid request type");
 }
 
 WSRequestHandler::~WSRequestHandler() {
 }
 
 void WSRequestHandler::SendOKResponse(obs_data_t* additionalFields) {
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_string(response, "status", "ok");
-    obs_data_set_string(response, "message-id", _messageId);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "status", "ok");
+	obs_data_set_string(response, "message-id", _messageId);
 
-    if (additionalFields)
-        obs_data_apply(response, additionalFields);
+	if (additionalFields)
+		obs_data_apply(response, additionalFields);
 
-    SendResponse(response);
+	SendResponse(response);
 }
 
 void WSRequestHandler::SendErrorResponse(const char* errorMessage) {
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_string(response, "status", "error");
-    obs_data_set_string(response, "error", errorMessage);
-    obs_data_set_string(response, "message-id", _messageId);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "status", "error");
+	obs_data_set_string(response, "error", errorMessage);
+	obs_data_set_string(response, "message-id", _messageId);
 
-    SendResponse(response);
+	SendResponse(response);
 }
 
 void WSRequestHandler::SendErrorResponse(obs_data_t* additionalFields) {
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_string(response, "status", "error");
-    obs_data_set_string(response, "message-id", _messageId);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "status", "error");
+	obs_data_set_string(response, "message-id", _messageId);
 
-    if (additionalFields)
-        obs_data_set_obj(response, "error", additionalFields);
+	if (additionalFields)
+		obs_data_set_obj(response, "error", additionalFields);
 
-    SendResponse(response);
+	SendResponse(response);
 }
 
-void WSRequestHandler::SendResponse(obs_data_t* response)  {
-    QString json = obs_data_get_json(response);
-    _client->sendTextMessage(json);
+void WSRequestHandler::SendResponse(obs_data_t* response) {
+	QString json = obs_data_get_json(response);
+	_client->sendTextMessage(json);
 
-    if (Config::Current()->DebugEnabled)
-        blog(LOG_DEBUG, "Response << '%s'", json.toUtf8().constData());
+	if (Config::Current()->DebugEnabled)
+		blog(LOG_DEBUG, "Response << '%s'", json.toUtf8().constData());
 }
 
 bool WSRequestHandler::hasField(QString name) {
-    if (!data || name.isEmpty() || name.isNull())
-        return false;
+	if (!data || name.isEmpty() || name.isNull())
+		return false;
 
-    return obs_data_has_user_value(data, name.toUtf8());
+	return obs_data_has_user_value(data, name.toUtf8());
 }

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -31,109 +31,115 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "obs-websocket.h"
 
 class WSRequestHandler : public QObject {
-  Q_OBJECT
+	Q_OBJECT
 
-  public:
-    explicit WSRequestHandler(QWebSocket* client);
-    ~WSRequestHandler();
-    void processIncomingMessage(QString textMessage);
-    bool hasField(QString name);
+public:
+	explicit WSRequestHandler(QWebSocket* client);
+	~WSRequestHandler();
+	void processIncomingMessage(QString textMessage);
+	bool hasField(QString name);
 
-  private:
-    QWebSocket* _client;
-    const char* _messageId;
-    const char* _requestType;
-    OBSDataAutoRelease data;
+private:
+	QWebSocket* _client;
+	const char* _messageId;
+	const char* _requestType;
+	OBSDataAutoRelease data;
 
-    void SendOKResponse(obs_data_t* additionalFields = NULL);
-    void SendErrorResponse(const char* errorMessage);
-    void SendErrorResponse(obs_data_t* additionalFields = NULL);
-    void SendResponse(obs_data_t* response);
+	void SendOKResponse(obs_data_t* additionalFields = NULL);
+	void SendErrorResponse(const char* errorMessage);
+	void SendErrorResponse(obs_data_t* additionalFields = NULL);
+	void SendResponse(obs_data_t* response);
 
-    static QHash<QString, void(*)(WSRequestHandler*)> messageMap;
-    static QSet<QString> authNotRequired;
+	static QHash<QString, void(*)(WSRequestHandler*)> messageMap;
+	static QSet<QString> authNotRequired;
 
-    static void HandleGetVersion(WSRequestHandler* req);
-    static void HandleGetAuthRequired(WSRequestHandler* req);
-    static void HandleAuthenticate(WSRequestHandler* req);
+	static void HandleGetVersion(WSRequestHandler* req);
+	static void HandleGetAuthRequired(WSRequestHandler* req);
+	static void HandleAuthenticate(WSRequestHandler* req);
 
-    static void HandleSetHeartbeat(WSRequestHandler* req);
+	static void HandleSetHeartbeat(WSRequestHandler* req);
 
-    static void HandleSetFilenameFormatting(WSRequestHandler* req);
-    static void HandleGetFilenameFormatting(WSRequestHandler* req);
+	static void HandleSetFilenameFormatting(WSRequestHandler* req);
+	static void HandleGetFilenameFormatting(WSRequestHandler* req);
 
-    static void HandleSetCurrentScene(WSRequestHandler* req);
-    static void HandleGetCurrentScene(WSRequestHandler* req);
-    static void HandleGetSceneList(WSRequestHandler* req);
+	static void HandleSetCurrentScene(WSRequestHandler* req);
+	static void HandleGetCurrentScene(WSRequestHandler* req);
+	static void HandleGetSceneList(WSRequestHandler* req);
 
-    static void HandleSetSceneItemRender(WSRequestHandler* req);
-    static void HandleSetSceneItemPosition(WSRequestHandler* req);
-    static void HandleSetSceneItemTransform(WSRequestHandler* req);
-    static void HandleSetSceneItemCrop(WSRequestHandler* req);
-    static void HandleGetSceneItemProperties(WSRequestHandler* req);
-    static void HandleSetSceneItemProperties(WSRequestHandler* req);
-    static void HandleResetSceneItem(WSRequestHandler* req);
+	static void HandleSetSceneItemRender(WSRequestHandler* req);
+	static void HandleSetSceneItemPosition(WSRequestHandler* req);
+	static void HandleSetSceneItemTransform(WSRequestHandler* req);
+	static void HandleSetSceneItemCrop(WSRequestHandler* req);
+	static void HandleGetSceneItemProperties(WSRequestHandler* req);
+	static void HandleSetSceneItemProperties(WSRequestHandler* req);
+	static void HandleResetSceneItem(WSRequestHandler* req);
 
-    static void HandleGetStreamingStatus(WSRequestHandler* req);
-    static void HandleStartStopStreaming(WSRequestHandler* req);
-    static void HandleStartStopRecording(WSRequestHandler* req);
-    static void HandleStartStreaming(WSRequestHandler* req);
-    static void HandleStopStreaming(WSRequestHandler* req);
-    static void HandleStartRecording(WSRequestHandler* req);
-    static void HandleStopRecording(WSRequestHandler* req);
+	static void HandleGetStreamingStatus(WSRequestHandler* req);
+	static void HandleStartStopStreaming(WSRequestHandler* req);
+	static void HandleStartStopRecording(WSRequestHandler* req);
+	static void HandleStartStreaming(WSRequestHandler* req);
+	static void HandleStopStreaming(WSRequestHandler* req);
+	static void HandleStartRecording(WSRequestHandler* req);
+	static void HandleStopRecording(WSRequestHandler* req);
 
-    static void HandleStartStopReplayBuffer(WSRequestHandler* req);
-    static void HandleStartReplayBuffer(WSRequestHandler* req);
-    static void HandleStopReplayBuffer(WSRequestHandler* req);
-    static void HandleSaveReplayBuffer(WSRequestHandler* req);
+	static void HandleStartStopReplayBuffer(WSRequestHandler* req);
+	static void HandleStartReplayBuffer(WSRequestHandler* req);
+	static void HandleStopReplayBuffer(WSRequestHandler* req);
+	static void HandleSaveReplayBuffer(WSRequestHandler* req);
 
-    static void HandleSetRecordingFolder(WSRequestHandler* req);
-    static void HandleGetRecordingFolder(WSRequestHandler* req);
+	static void HandleSetRecordingFolder(WSRequestHandler* req);
+	static void HandleGetRecordingFolder(WSRequestHandler* req);
 
-    static void HandleGetTransitionList(WSRequestHandler* req);
-    static void HandleGetCurrentTransition(WSRequestHandler* req);
-    static void HandleSetCurrentTransition(WSRequestHandler* req);
+	static void HandleGetTransitionList(WSRequestHandler* req);
+	static void HandleGetCurrentTransition(WSRequestHandler* req);
+	static void HandleSetCurrentTransition(WSRequestHandler* req);
 
-    static void HandleSetVolume(WSRequestHandler* req);
-    static void HandleGetVolume(WSRequestHandler* req);
-    static void HandleToggleMute(WSRequestHandler* req);
-    static void HandleSetMute(WSRequestHandler* req);
-    static void HandleGetMute(WSRequestHandler* req);
-    static void HandleSetSyncOffset(WSRequestHandler* req);
-    static void HandleGetSyncOffset(WSRequestHandler* req);
-    static void HandleGetSpecialSources(WSRequestHandler* req);
-    static void HandleGetSourcesList(WSRequestHandler* req);
-    static void HandleGetSourceTypesList(WSRequestHandler* req);
-    static void HandleGetSourceSettings(WSRequestHandler* req);
-    static void HandleSetSourceSettings(WSRequestHandler* req);
+	static void HandleSetVolume(WSRequestHandler* req);
+	static void HandleGetVolume(WSRequestHandler* req);
+	static void HandleToggleMute(WSRequestHandler* req);
+	static void HandleSetMute(WSRequestHandler* req);
+	static void HandleGetMute(WSRequestHandler* req);
+	static void HandleSetSyncOffset(WSRequestHandler* req);
+	static void HandleGetSyncOffset(WSRequestHandler* req);
+	static void HandleGetSpecialSources(WSRequestHandler* req);
+	static void HandleGetSourcesList(WSRequestHandler* req);
+	static void HandleGetSourceTypesList(WSRequestHandler* req);
+	static void HandleGetSourceSettings(WSRequestHandler* req);
+	static void HandleSetSourceSettings(WSRequestHandler* req);
 
-    static void HandleSetCurrentSceneCollection(WSRequestHandler* req);
-    static void HandleGetCurrentSceneCollection(WSRequestHandler* req);
-    static void HandleListSceneCollections(WSRequestHandler* req);
+	static void HandleSetCurrentSceneCollection(WSRequestHandler* req);
+	static void HandleGetCurrentSceneCollection(WSRequestHandler* req);
+	static void HandleListSceneCollections(WSRequestHandler* req);
 
-    static void HandleSetCurrentProfile(WSRequestHandler* req);
-    static void HandleGetCurrentProfile(WSRequestHandler* req);
-    static void HandleListProfiles(WSRequestHandler* req);
+	static void HandleSetCurrentProfile(WSRequestHandler* req);
+	static void HandleGetCurrentProfile(WSRequestHandler* req);
+	static void HandleListProfiles(WSRequestHandler* req);
 
-    static void HandleSetStreamSettings(WSRequestHandler* req);
-    static void HandleGetStreamSettings(WSRequestHandler* req);
-    static void HandleSaveStreamSettings(WSRequestHandler* req);
+	static void HandleSetStreamSettings(WSRequestHandler* req);
+	static void HandleGetStreamSettings(WSRequestHandler* req);
+	static void HandleSaveStreamSettings(WSRequestHandler* req);
 
-    static void HandleSetTransitionDuration(WSRequestHandler* req);
-    static void HandleGetTransitionDuration(WSRequestHandler* req);
+	static void HandleSetTransitionDuration(WSRequestHandler* req);
+	static void HandleGetTransitionDuration(WSRequestHandler* req);
 
-    static void HandleGetStudioModeStatus(WSRequestHandler* req);
-    static void HandleGetPreviewScene(WSRequestHandler* req);
-    static void HandleSetPreviewScene(WSRequestHandler* req);
-    static void HandleTransitionToProgram(WSRequestHandler* req);
-    static void HandleEnableStudioMode(WSRequestHandler* req);
-    static void HandleDisableStudioMode(WSRequestHandler* req);
-    static void HandleToggleStudioMode(WSRequestHandler* req);
+	static void HandleGetStudioModeStatus(WSRequestHandler* req);
+	static void HandleGetPreviewScene(WSRequestHandler* req);
+	static void HandleSetPreviewScene(WSRequestHandler* req);
+	static void HandleTransitionToProgram(WSRequestHandler* req);
+	static void HandleEnableStudioMode(WSRequestHandler* req);
+	static void HandleDisableStudioMode(WSRequestHandler* req);
+	static void HandleToggleStudioMode(WSRequestHandler* req);
 
-    static void HandleSetTextGDIPlusProperties(WSRequestHandler* req);
-    static void HandleGetTextGDIPlusProperties(WSRequestHandler* req);
-    static void HandleSetBrowserSourceProperties(WSRequestHandler* req);
-    static void HandleGetBrowserSourceProperties(WSRequestHandler* req);
+	static void HandleSetTextGDIPlusProperties(WSRequestHandler* req);
+	static void HandleGetTextGDIPlusProperties(WSRequestHandler* req);
+	static void HandleSetBrowserSourceProperties(WSRequestHandler* req);
+	static void HandleGetBrowserSourceProperties(WSRequestHandler* req);
+
+	static void HandleGetSourceTypeDefaults(WSRequestHandler* req);
+	static void HandleAddNewSourceToScene(WSRequestHandler* req);
+	static void HandleRemoveSourceFromScene(WSRequestHandler* req);
+	/*static void HandleAddVideoSourceToScene(WSRequestHandler* req);
+	static void HandleRemoveVideoSource(WSRequestHandler* req);*/
 };
 
 #endif // WSPROTOCOL_H

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -138,8 +138,6 @@ private:
 	static void HandleGetSourceTypeDefaults(WSRequestHandler* req);
 	static void HandleAddNewSourceToScene(WSRequestHandler* req);
 	static void HandleRemoveSourceFromScene(WSRequestHandler* req);
-	/*static void HandleAddVideoSourceToScene(WSRequestHandler* req);
-	static void HandleRemoveVideoSource(WSRequestHandler* req);*/
 };
 
 #endif // WSPROTOCOL_H

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -260,25 +260,25 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
 		OBSDataAutoRelease reqBounds = obs_data_get_obj(req->data, "bounds");
 		if (obs_data_has_user_value(reqBounds, "type")) {
 			const char* newBoundsType = obs_data_get_string(reqBounds, "type");
-			if (newBoundsType == "OBS_BOUNDS_NONE") {
+			if (strcmp(newBoundsType,"OBS_BOUNDS_NONE") == 0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_NONE);
 			}
-			else if (newBoundsType == "OBS_BOUNDS_STRETCH") {
+			else if (strcmp(newBoundsType,"OBS_BOUNDS_STRETCH")==0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_STRETCH);
 			}
-			else if (newBoundsType == "OBS_BOUNDS_SCALE_INNER") {
+			else if (strcmp(newBoundsType, "OBS_BOUNDS_SCALE_INNER")==0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_SCALE_INNER);
 			}
-			else if (newBoundsType == "OBS_BOUNDS_SCALE_OUTER") {
+			else if (strcmp(newBoundsType,"OBS_BOUNDS_SCALE_OUTER")==0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_SCALE_OUTER);
 			}
-			else if (newBoundsType == "OBS_BOUNDS_SCALE_TO_WIDTH") {
+			else if (strcmp(newBoundsType,"OBS_BOUNDS_SCALE_TO_WIDTH")==0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_SCALE_TO_WIDTH);
 			}
-			else if (newBoundsType == "OBS_BOUNDS_SCALE_TO_HEIGHT") {
+			else if (strcmp(newBoundsType,"OBS_BOUNDS_SCALE_TO_HEIGHT")==0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_SCALE_TO_HEIGHT);
 			}
-			else if (newBoundsType == "OBS_BOUNDS_MAX_ONLY") {
+			else if (strcmp(newBoundsType,"OBS_BOUNDS_MAX_ONLY")==0) {
 				obs_sceneitem_set_bounds_type(sceneItem, OBS_BOUNDS_MAX_ONLY);
 			}
 			else {

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -17,48 +17,48 @@
 * @since 4.3.0
 */
 void WSRequestHandler::HandleGetSourcesList(WSRequestHandler* req) {
-    OBSDataArrayAutoRelease sourcesArray = obs_data_array_create();
+	OBSDataArrayAutoRelease sourcesArray = obs_data_array_create();
 
-    auto sourceEnumProc = [](void* privateData, obs_source_t* source) -> bool {
-        obs_data_array_t* sourcesArray = (obs_data_array_t*)privateData;
+	auto sourceEnumProc = [](void* privateData, obs_source_t* source) -> bool {
+		obs_data_array_t* sourcesArray = (obs_data_array_t*)privateData;
 
-        OBSDataAutoRelease sourceData = obs_data_create();
-        obs_data_set_string(sourceData, "name", obs_source_get_name(source));
-        obs_data_set_string(sourceData, "typeId", obs_source_get_id(source));
+		OBSDataAutoRelease sourceData = obs_data_create();
+		obs_data_set_string(sourceData, "name", obs_source_get_name(source));
+		obs_data_set_string(sourceData, "typeId", obs_source_get_id(source));
 
-        QString typeString = "";
-        enum obs_source_type sourceType = obs_source_get_type(source);
-        switch (sourceType) {
-        case OBS_SOURCE_TYPE_INPUT:
-            typeString = "input";
-            break;
+		QString typeString = "";
+		enum obs_source_type sourceType = obs_source_get_type(source);
+		switch (sourceType) {
+		case OBS_SOURCE_TYPE_INPUT:
+			typeString = "input";
+			break;
 
-        case OBS_SOURCE_TYPE_FILTER:
-            typeString = "filter";
-            break;
+		case OBS_SOURCE_TYPE_FILTER:
+			typeString = "filter";
+			break;
 
-        case OBS_SOURCE_TYPE_TRANSITION:
-            typeString = "transition";
-            break;
+		case OBS_SOURCE_TYPE_TRANSITION:
+			typeString = "transition";
+			break;
 
-        case OBS_SOURCE_TYPE_SCENE:
-            typeString = "scene";
-            break;
+		case OBS_SOURCE_TYPE_SCENE:
+			typeString = "scene";
+			break;
 
-        default:
-            typeString = "unknown";
-            break;
-        }
-        obs_data_set_string(sourceData, "type", typeString.toUtf8());
+		default:
+			typeString = "unknown";
+			break;
+		}
+		obs_data_set_string(sourceData, "type", typeString.toUtf8());
 
-        obs_data_array_push_back(sourcesArray, sourceData);
-        return true;
-    };
-    obs_enum_sources(sourceEnumProc, sourcesArray);
+		obs_data_array_push_back(sourcesArray, sourceData);
+		return true;
+	};
+	obs_enum_sources(sourceEnumProc, sourcesArray);
 
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_array(response, "sources", sourcesArray);
-    req->SendOKResponse(response);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_array(response, "sources", sourcesArray);
+	req->SendOKResponse(response);
 }
 
 /**
@@ -84,58 +84,58 @@ void WSRequestHandler::HandleGetSourcesList(WSRequestHandler* req) {
 * @since 4.3.0
 */
 void WSRequestHandler::HandleGetSourceTypesList(WSRequestHandler* req) {
-    OBSDataArrayAutoRelease idsArray = obs_data_array_create();
+	OBSDataArrayAutoRelease idsArray = obs_data_array_create();
 
-    const char* id;
-    size_t idx = 0;
+	const char* id;
+	size_t idx = 0;
 
-    QHash<QString, QString> idTypes;
+	QHash<QString, QString> idTypes;
 
-    idx = 0;
-    while (obs_enum_input_types(idx++, &id)) {
-        idTypes.insert(id, "input");
-    }
+	idx = 0;
+	while (obs_enum_input_types(idx++, &id)) {
+		idTypes.insert(id, "input");
+	}
 
-    idx = 0;
-    while (obs_enum_filter_types(idx++, &id)) {
-        idTypes.insert(id, "filter");
-    }
+	idx = 0;
+	while (obs_enum_filter_types(idx++, &id)) {
+		idTypes.insert(id, "filter");
+	}
 
-    idx = 0;
-    while (obs_enum_transition_types(idx++, &id)) {
-        idTypes.insert(id, "transition");
-    }
+	idx = 0;
+	while (obs_enum_transition_types(idx++, &id)) {
+		idTypes.insert(id, "transition");
+	}
 
-    idx = 0;
-    while (obs_enum_source_types(idx++, &id)) {
-        OBSDataAutoRelease item = obs_data_create();
+	idx = 0;
+	while (obs_enum_source_types(idx++, &id)) {
+		OBSDataAutoRelease item = obs_data_create();
 
-        obs_data_set_string(item, "typeId", id);
-        obs_data_set_string(item, "displayName", obs_source_get_display_name(id));
-        obs_data_set_string(item, "type", idTypes.value(id, "other").toUtf8());
+		obs_data_set_string(item, "typeId", id);
+		obs_data_set_string(item, "displayName", obs_source_get_display_name(id));
+		obs_data_set_string(item, "type", idTypes.value(id, "other").toUtf8());
 
-        uint32_t caps = obs_get_source_output_flags(id);
-        OBSDataAutoRelease capsData = obs_data_create();
-        obs_data_set_bool(capsData, "isAsync", caps & OBS_SOURCE_ASYNC);
-        obs_data_set_bool(capsData, "hasVideo", caps & OBS_SOURCE_VIDEO);
-        obs_data_set_bool(capsData, "hasAudio", caps & OBS_SOURCE_AUDIO);
-        obs_data_set_bool(capsData, "canInteract", caps & OBS_SOURCE_INTERACTION);
-        obs_data_set_bool(capsData, "isComposite", caps & OBS_SOURCE_COMPOSITE);
-        obs_data_set_bool(capsData, "doNotDuplicate", caps & OBS_SOURCE_DO_NOT_DUPLICATE);
-        obs_data_set_bool(capsData, "doNotSelfMonitor", caps & OBS_SOURCE_DO_NOT_SELF_MONITOR);
-        obs_data_set_bool(capsData, "isDeprecated", caps & OBS_SOURCE_DEPRECATED);
+		uint32_t caps = obs_get_source_output_flags(id);
+		OBSDataAutoRelease capsData = obs_data_create();
+		obs_data_set_bool(capsData, "isAsync", caps & OBS_SOURCE_ASYNC);
+		obs_data_set_bool(capsData, "hasVideo", caps & OBS_SOURCE_VIDEO);
+		obs_data_set_bool(capsData, "hasAudio", caps & OBS_SOURCE_AUDIO);
+		obs_data_set_bool(capsData, "canInteract", caps & OBS_SOURCE_INTERACTION);
+		obs_data_set_bool(capsData, "isComposite", caps & OBS_SOURCE_COMPOSITE);
+		obs_data_set_bool(capsData, "doNotDuplicate", caps & OBS_SOURCE_DO_NOT_DUPLICATE);
+		obs_data_set_bool(capsData, "doNotSelfMonitor", caps & OBS_SOURCE_DO_NOT_SELF_MONITOR);
+		obs_data_set_bool(capsData, "isDeprecated", caps & OBS_SOURCE_DEPRECATED);
 
-        obs_data_set_obj(item, "caps", capsData);
+		obs_data_set_obj(item, "caps", capsData);
 
-        OBSDataAutoRelease defaultSettings = obs_get_source_defaults(id);
-        obs_data_set_obj(item, "defaultSettings", defaultSettings);
+		OBSDataAutoRelease defaultSettings = obs_get_source_defaults(id);
+		obs_data_set_obj(item, "defaultSettings", defaultSettings);
 
-        obs_data_array_push_back(idsArray, item);
-    }
+		obs_data_array_push_back(idsArray, item);
+	}
 
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_array(response, "types", idsArray);
-    req->SendOKResponse(response);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_array(response, "types", idsArray);
+	req->SendOKResponse(response);
 }
 
 /**
@@ -153,25 +153,25 @@ void WSRequestHandler::HandleGetSourceTypesList(WSRequestHandler* req) {
 * @since 4.0.0
 */
 void WSRequestHandler::HandleGetVolume(WSRequestHandler* req) {
-    if (!req->hasField("source")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    if (!sourceName.isEmpty()) {
-        OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	QString sourceName = obs_data_get_string(req->data, "source");
+	if (!sourceName.isEmpty()) {
+		OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
 
-        OBSDataAutoRelease response = obs_data_create();
-        obs_data_set_string(response, "name", sourceName.toUtf8());
-        obs_data_set_double(response, "volume", obs_source_get_volume(source));
-        obs_data_set_bool(response, "muted", obs_source_muted(source));
+		OBSDataAutoRelease response = obs_data_create();
+		obs_data_set_string(response, "name", sourceName.toUtf8());
+		obs_data_set_double(response, "volume", obs_source_get_volume(source));
+		obs_data_set_bool(response, "muted", obs_source_muted(source));
 
-        req->SendOKResponse(response);
-    }
-    else {
-        req->SendErrorResponse("invalid request parameters");
-    }
+		req->SendOKResponse(response);
+	}
+	else {
+		req->SendErrorResponse("invalid request parameters");
+	}
 }
 
 /**
@@ -185,31 +185,31 @@ void WSRequestHandler::HandleGetVolume(WSRequestHandler* req) {
  * @category sources
  * @since 4.0.0
  */
- void WSRequestHandler::HandleSetVolume(WSRequestHandler* req) {
-    if (!req->hasField("source") ||
-        !req->hasField("volume"))
-    {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+void WSRequestHandler::HandleSetVolume(WSRequestHandler* req) {
+	if (!req->hasField("source") ||
+		!req->hasField("volume"))
+	{
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    float sourceVolume = obs_data_get_double(req->data, "volume");
+	QString sourceName = obs_data_get_string(req->data, "source");
+	float sourceVolume = obs_data_get_double(req->data, "volume");
 
-    if (sourceName.isEmpty() ||
-        sourceVolume < 0.0 || sourceVolume > 1.0) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	if (sourceName.isEmpty() ||
+		sourceVolume < 0.0 || sourceVolume > 1.0) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
-    if (!source) {
-        req->SendErrorResponse("specified source doesn't exist");
-        return;
-    }
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
 
-    obs_source_set_volume(source, sourceVolume);
-    req->SendOKResponse();
+	obs_source_set_volume(source, sourceVolume);
+	req->SendOKResponse();
 }
 
 /**
@@ -226,28 +226,28 @@ void WSRequestHandler::HandleGetVolume(WSRequestHandler* req) {
 * @since 4.0.0
 */
 void WSRequestHandler::HandleGetMute(WSRequestHandler* req) {
-    if (!req->hasField("source")) {
-        req->SendErrorResponse("mssing request parameters");
-        return;
-    }
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("mssing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    if (sourceName.isEmpty()) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	QString sourceName = obs_data_get_string(req->data, "source");
+	if (sourceName.isEmpty()) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
-    if (!source) {
-        req->SendErrorResponse("specified source doesn't exist");
-        return;
-    }
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
 
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_string(response, "name", obs_source_get_name(source));
-    obs_data_set_bool(response, "muted", obs_source_muted(source));
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "name", obs_source_get_name(source));
+	obs_data_set_bool(response, "muted", obs_source_muted(source));
 
-    req->SendOKResponse(response);
+	req->SendOKResponse(response);
 }
 
 /**
@@ -262,28 +262,28 @@ void WSRequestHandler::HandleGetMute(WSRequestHandler* req) {
  * @since 4.0.0
  */
 void WSRequestHandler::HandleSetMute(WSRequestHandler* req) {
-    if (!req->hasField("source") ||
-        !req->hasField("mute")) {
-        req->SendErrorResponse("mssing request parameters");
-        return;
-    }
+	if (!req->hasField("source") ||
+		!req->hasField("mute")) {
+		req->SendErrorResponse("mssing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    bool mute = obs_data_get_bool(req->data, "mute");
+	QString sourceName = obs_data_get_string(req->data, "source");
+	bool mute = obs_data_get_bool(req->data, "mute");
 
-    if (sourceName.isEmpty()) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	if (sourceName.isEmpty()) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
-    if (!source) {
-        req->SendErrorResponse("specified source doesn't exist");
-        return;
-    }
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
 
-    obs_source_set_muted(source, mute);
-    req->SendOKResponse();
+	obs_source_set_muted(source, mute);
+	req->SendOKResponse();
 }
 
 /**
@@ -297,25 +297,25 @@ void WSRequestHandler::HandleSetMute(WSRequestHandler* req) {
 * @since 4.0.0
 */
 void WSRequestHandler::HandleToggleMute(WSRequestHandler* req) {
-    if (!req->hasField("source")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    if (sourceName.isEmpty()) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	QString sourceName = obs_data_get_string(req->data, "source");
+	if (sourceName.isEmpty()) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
-    if (!source) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    obs_source_set_muted(source, !obs_source_muted(source));
-    req->SendOKResponse();
+	obs_source_set_muted(source, !obs_source_muted(source));
+	req->SendOKResponse();
 }
 
 /**
@@ -330,27 +330,27 @@ void WSRequestHandler::HandleToggleMute(WSRequestHandler* req) {
  * @since 4.2.0
  */
 void WSRequestHandler::HandleSetSyncOffset(WSRequestHandler* req) {
-    if (!req->hasField("source") || !req->hasField("offset")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("source") || !req->hasField("offset")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    int64_t sourceSyncOffset = (int64_t)obs_data_get_int(req->data, "offset");
+	QString sourceName = obs_data_get_string(req->data, "source");
+	int64_t sourceSyncOffset = (int64_t)obs_data_get_int(req->data, "offset");
 
-    if (sourceName.isEmpty() || sourceSyncOffset < 0) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	if (sourceName.isEmpty() || sourceSyncOffset < 0) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
-    if (!source) {
-        req->SendErrorResponse("specified source doesn't exist");
-        return;
-    }
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
 
-    obs_source_set_sync_offset(source, sourceSyncOffset);
-    req->SendOKResponse();
+	obs_source_set_sync_offset(source, sourceSyncOffset);
+	req->SendOKResponse();
 }
 
 /**
@@ -367,23 +367,24 @@ void WSRequestHandler::HandleSetSyncOffset(WSRequestHandler* req) {
  * @since 4.2.0
  */
 void WSRequestHandler::HandleGetSyncOffset(WSRequestHandler* req) {
-    if (!req->hasField("source")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    QString sourceName = obs_data_get_string(req->data, "source");
-    if (!sourceName.isEmpty()) {
-        OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	QString sourceName = obs_data_get_string(req->data, "source");
+	if (!sourceName.isEmpty()) {
+		OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
 
-        OBSDataAutoRelease response = obs_data_create();
-        obs_data_set_string(response, "name", sourceName.toUtf8());
-        obs_data_set_int(response, "offset", obs_source_get_sync_offset(source));
+		OBSDataAutoRelease response = obs_data_create();
+		obs_data_set_string(response, "name", sourceName.toUtf8());
+		obs_data_set_int(response, "offset", obs_source_get_sync_offset(source));
 
-        req->SendOKResponse(response);
-    } else {
-        req->SendErrorResponse("invalid request parameters");
-    }
+		req->SendOKResponse(response);
+	}
+	else {
+		req->SendErrorResponse("invalid request parameters");
+	}
 }
 
 /**
@@ -402,35 +403,35 @@ void WSRequestHandler::HandleGetSyncOffset(WSRequestHandler* req) {
 * @since 4.3.0
 */
 void WSRequestHandler::HandleGetSourceSettings(WSRequestHandler* req) {
-    if (!req->hasField("sourceName")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("sourceName")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    const char* sourceName = obs_data_get_string(req->data, "sourceName");
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName);
-    if (!source) {
-        req->SendErrorResponse("specified source doesn't exist");
-        return;
-    }
+	const char* sourceName = obs_data_get_string(req->data, "sourceName");
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName);
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
 
-    if (req->hasField("sourceType")) {
-        QString actualSourceType = obs_source_get_id(source);
-        QString requestedType = obs_data_get_string(req->data, "sourceType");
+	if (req->hasField("sourceType")) {
+		QString actualSourceType = obs_source_get_id(source);
+		QString requestedType = obs_data_get_string(req->data, "sourceType");
 
-        if (actualSourceType != requestedType) {
-            req->SendErrorResponse("specified source exists but is not of expected type");
-            return;
-        }
-    }
+		if (actualSourceType != requestedType) {
+			req->SendErrorResponse("specified source exists but is not of expected type");
+			return;
+		}
+	}
 
-    OBSDataAutoRelease sourceSettings = obs_source_get_settings(source);
+	OBSDataAutoRelease sourceSettings = obs_source_get_settings(source);
 
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_string(response, "sourceName", obs_source_get_name(source));
-    obs_data_set_string(response, "sourceType", obs_source_get_id(source));
-    obs_data_set_obj(response, "sourceSettings", sourceSettings);
-    req->SendOKResponse(response);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
+	obs_data_set_string(response, "sourceType", obs_source_get_id(source));
+	obs_data_set_obj(response, "sourceSettings", sourceSettings);
+	req->SendOKResponse(response);
 }
 
 /**
@@ -450,43 +451,43 @@ void WSRequestHandler::HandleGetSourceSettings(WSRequestHandler* req) {
 * @since 4.3.0
 */
 void WSRequestHandler::HandleSetSourceSettings(WSRequestHandler* req) {
-    if (!req->hasField("sourceName") || !req->hasField("sourceSettings")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("sourceName") || !req->hasField("sourceSettings")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    const char* sourceName = obs_data_get_string(req->data, "sourceName");
-    OBSSourceAutoRelease source = obs_get_source_by_name(sourceName);
-    if (!source) {
-        req->SendErrorResponse("specified source doesn't exist");
-        return;
-    }
+	const char* sourceName = obs_data_get_string(req->data, "sourceName");
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName);
+	if (!source) {
+		req->SendErrorResponse("specified source doesn't exist");
+		return;
+	}
 
-    if (req->hasField("sourceType")) {
-        QString actualSourceType = obs_source_get_id(source);
-        QString requestedType = obs_data_get_string(req->data, "sourceType");
+	if (req->hasField("sourceType")) {
+		QString actualSourceType = obs_source_get_id(source);
+		QString requestedType = obs_data_get_string(req->data, "sourceType");
 
-        if (actualSourceType != requestedType) {
-            req->SendErrorResponse("specified source exists but is not of expected type");
-            return;
-        }
-    }
+		if (actualSourceType != requestedType) {
+			req->SendErrorResponse("specified source exists but is not of expected type");
+			return;
+		}
+	}
 
-    OBSDataAutoRelease currentSettings = obs_source_get_settings(source);
-    OBSDataAutoRelease newSettings = obs_data_get_obj(req->data, "sourceSettings");
+	OBSDataAutoRelease currentSettings = obs_source_get_settings(source);
+	OBSDataAutoRelease newSettings = obs_data_get_obj(req->data, "sourceSettings");
 
-    OBSDataAutoRelease sourceSettings = obs_data_create();
-    obs_data_apply(sourceSettings, currentSettings);
-    obs_data_apply(sourceSettings, newSettings);
+	OBSDataAutoRelease sourceSettings = obs_data_create();
+	obs_data_apply(sourceSettings, currentSettings);
+	obs_data_apply(sourceSettings, newSettings);
 
-    obs_source_update(source, sourceSettings);
-    obs_source_update_properties(source);
+	obs_source_update(source, sourceSettings);
+	obs_source_update_properties(source);
 
-    OBSDataAutoRelease response = obs_data_create();
-    obs_data_set_string(response, "sourceName", obs_source_get_name(source));
-    obs_data_set_string(response, "sourceType", obs_source_get_id(source));
-    obs_data_set_obj(response, "sourceSettings", sourceSettings);
-    req->SendOKResponse(response);
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
+	obs_data_set_string(response, "sourceType", obs_source_get_id(source));
+	obs_data_set_obj(response, "sourceSettings", sourceSettings);
+	req->SendOKResponse(response);
 }
 
 /**
@@ -529,42 +530,44 @@ void WSRequestHandler::HandleSetSourceSettings(WSRequestHandler* req) {
  * @category sources
  * @since 4.1.0
  */
- void WSRequestHandler::HandleGetTextGDIPlusProperties(WSRequestHandler* req) {
-    // TODO: source settings are independent of any scene, so there's no need
-    // to target a specific scene
+void WSRequestHandler::HandleGetTextGDIPlusProperties(WSRequestHandler* req) {
+	// TODO: source settings are independent of any scene, so there's no need
+	// to target a specific scene
 
-    const char* itemName = obs_data_get_string(req->data, "source");
-    if (!itemName) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	const char* itemName = obs_data_get_string(req->data, "source");
+	if (!itemName) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    const char* sceneName = obs_data_get_string(req->data, "scene-name");
-    OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
-    if (!scene) {
-        req->SendErrorResponse("requested scene doesn't exist");
-        return;
-    }
+	const char* sceneName = obs_data_get_string(req->data, "scene-name");
+	OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
+	if (!scene) {
+		req->SendErrorResponse("requested scene doesn't exist");
+		return;
+	}
 
-    OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
-    if (sceneItem) {
-        OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
-        const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
+	OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
+	if (sceneItem) {
+		OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
+		const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
 
-        if (strcmp(sceneItemSourceId, "text_gdiplus") == 0) {
-            OBSDataAutoRelease response = obs_source_get_settings(sceneItemSource);
-            obs_data_set_string(response, "source", itemName);
-            obs_data_set_string(response, "scene-name", sceneName);
-            obs_data_set_bool(response, "render",
-                obs_sceneitem_visible(sceneItem));
+		if (strcmp(sceneItemSourceId, "text_gdiplus") == 0) {
+			OBSDataAutoRelease response = obs_source_get_settings(sceneItemSource);
+			obs_data_set_string(response, "source", itemName);
+			obs_data_set_string(response, "scene-name", sceneName);
+			obs_data_set_bool(response, "render",
+				obs_sceneitem_visible(sceneItem));
 
-            req->SendOKResponse(response);
-        } else {
-            req->SendErrorResponse("not text gdi plus source");
-        }
-    } else {
-        req->SendErrorResponse("specified scene item doesn't exist");
-    }
+			req->SendOKResponse(response);
+		}
+		else {
+			req->SendErrorResponse("not text gdi plus source");
+		}
+	}
+	else {
+		req->SendErrorResponse("specified scene item doesn't exist");
+	}
 }
 
 /**
@@ -607,191 +610,193 @@ void WSRequestHandler::HandleSetSourceSettings(WSRequestHandler* req) {
  * @since 4.1.0
  */
 void WSRequestHandler::HandleSetTextGDIPlusProperties(WSRequestHandler* req) {
-    // TODO: source settings are independent of any scene, so there's no need
-    // to target a specific scene
+	// TODO: source settings are independent of any scene, so there's no need
+	// to target a specific scene
 
-    if (!req->hasField("source")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    const char* itemName = obs_data_get_string(req->data, "source");
-    if (!itemName) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	const char* itemName = obs_data_get_string(req->data, "source");
+	if (!itemName) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    const char* sceneName = obs_data_get_string(req->data, "scene-name");
-    OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
-    if (!scene) {
-        req->SendErrorResponse("requested scene doesn't exist");
-        return;
-    }
+	const char* sceneName = obs_data_get_string(req->data, "scene-name");
+	OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
+	if (!scene) {
+		req->SendErrorResponse("requested scene doesn't exist");
+		return;
+	}
 
-    OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
-    if (sceneItem) {
-        OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
-        const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
+	OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
+	if (sceneItem) {
+		OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
+		const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
 
-        if (strcmp(sceneItemSourceId, "text_gdiplus") == 0) {
-            OBSDataAutoRelease settings = obs_source_get_settings(sceneItemSource);
+		if (strcmp(sceneItemSourceId, "text_gdiplus") == 0) {
+			OBSDataAutoRelease settings = obs_source_get_settings(sceneItemSource);
 
-            if (req->hasField("align")) {
-                obs_data_set_string(settings, "align",
-                    obs_data_get_string(req->data, "align"));
-            }
+			if (req->hasField("align")) {
+				obs_data_set_string(settings, "align",
+					obs_data_get_string(req->data, "align"));
+			}
 
-            if (req->hasField("bk_color")) {
-                obs_data_set_int(settings, "bk_color",
-                    obs_data_get_int(req->data, "bk_color"));
-            }
+			if (req->hasField("bk_color")) {
+				obs_data_set_int(settings, "bk_color",
+					obs_data_get_int(req->data, "bk_color"));
+			}
 
-            if (req->hasField("bk-opacity")) {
-                obs_data_set_int(settings, "bk_opacity",
-                    obs_data_get_int(req->data, "bk_opacity"));
-            }
+			if (req->hasField("bk-opacity")) {
+				obs_data_set_int(settings, "bk_opacity",
+					obs_data_get_int(req->data, "bk_opacity"));
+			}
 
-            if (req->hasField("chatlog")) {
-                obs_data_set_bool(settings, "chatlog",
-                    obs_data_get_bool(req->data, "chatlog"));
-            }
+			if (req->hasField("chatlog")) {
+				obs_data_set_bool(settings, "chatlog",
+					obs_data_get_bool(req->data, "chatlog"));
+			}
 
-            if (req->hasField("chatlog_lines")) {
-                obs_data_set_int(settings, "chatlog_lines",
-                    obs_data_get_int(req->data, "chatlog_lines"));
-            }
+			if (req->hasField("chatlog_lines")) {
+				obs_data_set_int(settings, "chatlog_lines",
+					obs_data_get_int(req->data, "chatlog_lines"));
+			}
 
-            if (req->hasField("color")) {
-                obs_data_set_int(settings, "color",
-                    obs_data_get_int(req->data, "color"));
-            }
+			if (req->hasField("color")) {
+				obs_data_set_int(settings, "color",
+					obs_data_get_int(req->data, "color"));
+			}
 
-            if (req->hasField("extents")) {
-                obs_data_set_bool(settings, "extents",
-                    obs_data_get_bool(req->data, "extents"));
-            }
+			if (req->hasField("extents")) {
+				obs_data_set_bool(settings, "extents",
+					obs_data_get_bool(req->data, "extents"));
+			}
 
-            if (req->hasField("extents_wrap")) {
-                obs_data_set_bool(settings, "extents_wrap",
-                    obs_data_get_bool(req->data, "extents_wrap"));
-            }
+			if (req->hasField("extents_wrap")) {
+				obs_data_set_bool(settings, "extents_wrap",
+					obs_data_get_bool(req->data, "extents_wrap"));
+			}
 
-            if (req->hasField("extents_cx")) {
-                obs_data_set_int(settings, "extents_cx",
-                    obs_data_get_int(req->data, "extents_cx"));
-            }
+			if (req->hasField("extents_cx")) {
+				obs_data_set_int(settings, "extents_cx",
+					obs_data_get_int(req->data, "extents_cx"));
+			}
 
-            if (req->hasField("extents_cy")) {
-                obs_data_set_int(settings, "extents_cy",
-                    obs_data_get_int(req->data, "extents_cy"));
-            }
+			if (req->hasField("extents_cy")) {
+				obs_data_set_int(settings, "extents_cy",
+					obs_data_get_int(req->data, "extents_cy"));
+			}
 
-            if (req->hasField("file")) {
-                obs_data_set_string(settings, "file",
-                    obs_data_get_string(req->data, "file"));
-            }
+			if (req->hasField("file")) {
+				obs_data_set_string(settings, "file",
+					obs_data_get_string(req->data, "file"));
+			}
 
-            if (req->hasField("font")) {
-                OBSDataAutoRelease font_obj = obs_data_get_obj(settings, "font");
-                if (font_obj) {
-                    OBSDataAutoRelease req_font_obj = obs_data_get_obj(req->data, "font");
+			if (req->hasField("font")) {
+				OBSDataAutoRelease font_obj = obs_data_get_obj(settings, "font");
+				if (font_obj) {
+					OBSDataAutoRelease req_font_obj = obs_data_get_obj(req->data, "font");
 
-                    if (obs_data_has_user_value(req_font_obj, "face")) {
-                        obs_data_set_string(font_obj, "face",
-                            obs_data_get_string(req_font_obj, "face"));
-                    }
+					if (obs_data_has_user_value(req_font_obj, "face")) {
+						obs_data_set_string(font_obj, "face",
+							obs_data_get_string(req_font_obj, "face"));
+					}
 
-                    if (obs_data_has_user_value(req_font_obj, "flags")) {
-                        obs_data_set_int(font_obj, "flags",
-                            obs_data_get_int(req_font_obj, "flags"));
-                    }
+					if (obs_data_has_user_value(req_font_obj, "flags")) {
+						obs_data_set_int(font_obj, "flags",
+							obs_data_get_int(req_font_obj, "flags"));
+					}
 
-                    if (obs_data_has_user_value(req_font_obj, "size")) {
-                        obs_data_set_int(font_obj, "size",
-                            obs_data_get_int(req_font_obj, "size"));
-                    }
+					if (obs_data_has_user_value(req_font_obj, "size")) {
+						obs_data_set_int(font_obj, "size",
+							obs_data_get_int(req_font_obj, "size"));
+					}
 
-                    if (obs_data_has_user_value(req_font_obj, "style")) {
-                        obs_data_set_string(font_obj, "style",
-                            obs_data_get_string(req_font_obj, "style"));
-                    }
-                }
-            }
+					if (obs_data_has_user_value(req_font_obj, "style")) {
+						obs_data_set_string(font_obj, "style",
+							obs_data_get_string(req_font_obj, "style"));
+					}
+				}
+			}
 
-            if (req->hasField("gradient")) {
-                obs_data_set_bool(settings, "gradient",
-                    obs_data_get_bool(req->data, "gradient"));
-            }
+			if (req->hasField("gradient")) {
+				obs_data_set_bool(settings, "gradient",
+					obs_data_get_bool(req->data, "gradient"));
+			}
 
-            if (req->hasField("gradient_color")) {
-                obs_data_set_int(settings, "gradient_color",
-                    obs_data_get_int(req->data, "gradient_color"));
-            }
+			if (req->hasField("gradient_color")) {
+				obs_data_set_int(settings, "gradient_color",
+					obs_data_get_int(req->data, "gradient_color"));
+			}
 
-            if (req->hasField("gradient_dir")) {
-                obs_data_set_double(settings, "gradient_dir",
-                    obs_data_get_double(req->data, "gradient_dir"));
-            }
+			if (req->hasField("gradient_dir")) {
+				obs_data_set_double(settings, "gradient_dir",
+					obs_data_get_double(req->data, "gradient_dir"));
+			}
 
-            if (req->hasField("gradient_opacity")) {
-                obs_data_set_int(settings, "gradient_opacity",
-                    obs_data_get_int(req->data, "gradient_opacity"));
-            }
+			if (req->hasField("gradient_opacity")) {
+				obs_data_set_int(settings, "gradient_opacity",
+					obs_data_get_int(req->data, "gradient_opacity"));
+			}
 
-            if (req->hasField("outline")) {
-                obs_data_set_bool(settings, "outline",
-                    obs_data_get_bool(req->data, "outline"));
-            }
+			if (req->hasField("outline")) {
+				obs_data_set_bool(settings, "outline",
+					obs_data_get_bool(req->data, "outline"));
+			}
 
-            if (req->hasField("outline_size")) {
-                obs_data_set_int(settings, "outline_size",
-                    obs_data_get_int(req->data, "outline_size"));
-            }
+			if (req->hasField("outline_size")) {
+				obs_data_set_int(settings, "outline_size",
+					obs_data_get_int(req->data, "outline_size"));
+			}
 
-            if (req->hasField("outline_color")) {
-                obs_data_set_int(settings, "outline_color",
-                    obs_data_get_int(req->data, "outline_color"));
-            }
+			if (req->hasField("outline_color")) {
+				obs_data_set_int(settings, "outline_color",
+					obs_data_get_int(req->data, "outline_color"));
+			}
 
-            if (req->hasField("outline_opacity")) {
-                obs_data_set_int(settings, "outline_opacity",
-                    obs_data_get_int(req->data, "outline_opacity"));
-            }
+			if (req->hasField("outline_opacity")) {
+				obs_data_set_int(settings, "outline_opacity",
+					obs_data_get_int(req->data, "outline_opacity"));
+			}
 
-            if (req->hasField("read_from_file")) {
-                obs_data_set_bool(settings, "read_from_file",
-                    obs_data_get_bool(req->data, "read_from_file"));
-            }
+			if (req->hasField("read_from_file")) {
+				obs_data_set_bool(settings, "read_from_file",
+					obs_data_get_bool(req->data, "read_from_file"));
+			}
 
-            if (req->hasField("text")) {
-                obs_data_set_string(settings, "text",
-                    obs_data_get_string(req->data, "text"));
-            }
+			if (req->hasField("text")) {
+				obs_data_set_string(settings, "text",
+					obs_data_get_string(req->data, "text"));
+			}
 
-            if (req->hasField("valign")) {
-                obs_data_set_string(settings, "valign",
-                    obs_data_get_string(req->data, "valign"));
-            }
+			if (req->hasField("valign")) {
+				obs_data_set_string(settings, "valign",
+					obs_data_get_string(req->data, "valign"));
+			}
 
-            if (req->hasField("vertical")) {
-                obs_data_set_bool(settings, "vertical",
-                    obs_data_get_bool(req->data, "vertical"));
-            }
+			if (req->hasField("vertical")) {
+				obs_data_set_bool(settings, "vertical",
+					obs_data_get_bool(req->data, "vertical"));
+			}
 
-            obs_source_update(sceneItemSource, settings);
+			obs_source_update(sceneItemSource, settings);
 
-            if (req->hasField("render")) {
-                obs_sceneitem_set_visible(sceneItem,
-                    obs_data_get_bool(req->data, "render"));
-            }
+			if (req->hasField("render")) {
+				obs_sceneitem_set_visible(sceneItem,
+					obs_data_get_bool(req->data, "render"));
+			}
 
-            req->SendOKResponse();
-        } else {
-            req->SendErrorResponse("not text gdi plus source");
-        }
-    } else {
-        req->SendErrorResponse("specified scene item doesn't exist");
-    }
+			req->SendOKResponse();
+		}
+		else {
+			req->SendErrorResponse("not text gdi plus source");
+		}
+	}
+	else {
+		req->SendErrorResponse("specified scene item doesn't exist");
+	}
 }
 
 /**
@@ -816,41 +821,43 @@ void WSRequestHandler::HandleSetTextGDIPlusProperties(WSRequestHandler* req) {
  * @since 4.1.0
  */
 void WSRequestHandler::HandleGetBrowserSourceProperties(WSRequestHandler* req) {
-    // TODO: source settings are independent of any scene, so there's no need
-    // to target a specific scene
+	// TODO: source settings are independent of any scene, so there's no need
+	// to target a specific scene
 
-    const char* itemName = obs_data_get_string(req->data, "source");
-    if (!itemName) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	const char* itemName = obs_data_get_string(req->data, "source");
+	if (!itemName) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    const char* sceneName = obs_data_get_string(req->data, "scene-name");
-    OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
-    if (!scene) {
-        req->SendErrorResponse("requested scene doesn't exist");
-        return;
-    }
+	const char* sceneName = obs_data_get_string(req->data, "scene-name");
+	OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
+	if (!scene) {
+		req->SendErrorResponse("requested scene doesn't exist");
+		return;
+	}
 
-    OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
-    if (sceneItem) {
-        OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
-        const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
+	OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
+	if (sceneItem) {
+		OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
+		const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
 
-        if (strcmp(sceneItemSourceId, "browser_source") == 0) {
-            OBSDataAutoRelease response = obs_source_get_settings(sceneItemSource);
-            obs_data_set_string(response, "source", itemName);
-            obs_data_set_string(response, "scene-name", sceneName);
-            obs_data_set_bool(response, "render",
-                obs_sceneitem_visible(sceneItem));
+		if (strcmp(sceneItemSourceId, "browser_source") == 0) {
+			OBSDataAutoRelease response = obs_source_get_settings(sceneItemSource);
+			obs_data_set_string(response, "source", itemName);
+			obs_data_set_string(response, "scene-name", sceneName);
+			obs_data_set_bool(response, "render",
+				obs_sceneitem_visible(sceneItem));
 
-            req->SendOKResponse(response);
-        } else {
-            req->SendErrorResponse("not browser source");
-        }
-    } else {
-        req->SendErrorResponse("specified scene item doesn't exist");
-    }
+			req->SendOKResponse(response);
+		}
+		else {
+			req->SendErrorResponse("not browser source");
+		}
+	}
+	else {
+		req->SendErrorResponse("specified scene item doesn't exist");
+	}
 }
 
 /**
@@ -874,94 +881,96 @@ void WSRequestHandler::HandleGetBrowserSourceProperties(WSRequestHandler* req) {
  * @since 4.1.0
  */
 void WSRequestHandler::HandleSetBrowserSourceProperties(WSRequestHandler* req) {
-    // TODO: source settings are independent of any scene, so there's no need
-    // to target a specific scene
+	// TODO: source settings are independent of any scene, so there's no need
+	// to target a specific scene
 
-    if (!req->hasField("source")) {
-        req->SendErrorResponse("missing request parameters");
-        return;
-    }
+	if (!req->hasField("source")) {
+		req->SendErrorResponse("missing request parameters");
+		return;
+	}
 
-    const char* itemName = obs_data_get_string(req->data, "source");
-    if (!itemName) {
-        req->SendErrorResponse("invalid request parameters");
-        return;
-    }
+	const char* itemName = obs_data_get_string(req->data, "source");
+	if (!itemName) {
+		req->SendErrorResponse("invalid request parameters");
+		return;
+	}
 
-    const char* sceneName = obs_data_get_string(req->data, "scene-name");
-    OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
-    if (!scene) {
-        req->SendErrorResponse("requested scene doesn't exist");
-        return;
-    }
+	const char* sceneName = obs_data_get_string(req->data, "scene-name");
+	OBSSourceAutoRelease scene = Utils::GetSceneFromNameOrCurrent(sceneName);
+	if (!scene) {
+		req->SendErrorResponse("requested scene doesn't exist");
+		return;
+	}
 
-    OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
-    if (sceneItem) {
-        OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
-        const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
+	OBSSceneItemAutoRelease sceneItem = Utils::GetSceneItemFromName(scene, itemName);
+	if (sceneItem) {
+		OBSSource sceneItemSource = obs_sceneitem_get_source(sceneItem);
+		const char* sceneItemSourceId = obs_source_get_id(sceneItemSource);
 
-        if (strcmp(sceneItemSourceId, "browser_source") == 0) {
-            OBSDataAutoRelease settings = obs_source_get_settings(sceneItemSource);
+		if (strcmp(sceneItemSourceId, "browser_source") == 0) {
+			OBSDataAutoRelease settings = obs_source_get_settings(sceneItemSource);
 
-            if (req->hasField("restart_when_active")) {
-                obs_data_set_bool(settings, "restart_when_active",
-                    obs_data_get_bool(req->data, "restart_when_active"));
-            }
+			if (req->hasField("restart_when_active")) {
+				obs_data_set_bool(settings, "restart_when_active",
+					obs_data_get_bool(req->data, "restart_when_active"));
+			}
 
-            if (req->hasField("shutdown")) {
-                obs_data_set_bool(settings, "shutdown",
-                    obs_data_get_bool(req->data, "shutdown"));
-            }
+			if (req->hasField("shutdown")) {
+				obs_data_set_bool(settings, "shutdown",
+					obs_data_get_bool(req->data, "shutdown"));
+			}
 
-            if (req->hasField("is_local_file")) {
-                obs_data_set_bool(settings, "is_local_file",
-                    obs_data_get_bool(req->data, "is_local_file"));
-            }
+			if (req->hasField("is_local_file")) {
+				obs_data_set_bool(settings, "is_local_file",
+					obs_data_get_bool(req->data, "is_local_file"));
+			}
 
-            if (req->hasField("local_file")) {
-                obs_data_set_string(settings, "local_file",
-                    obs_data_get_string(req->data, "local_file"));
-            }
+			if (req->hasField("local_file")) {
+				obs_data_set_string(settings, "local_file",
+					obs_data_get_string(req->data, "local_file"));
+			}
 
-            if (req->hasField("url")) {
-                obs_data_set_string(settings, "url",
-                    obs_data_get_string(req->data, "url"));
-            }
+			if (req->hasField("url")) {
+				obs_data_set_string(settings, "url",
+					obs_data_get_string(req->data, "url"));
+			}
 
-            if (req->hasField("css")) {
-                obs_data_set_string(settings, "css",
-                    obs_data_get_string(req->data, "css"));
-            }
+			if (req->hasField("css")) {
+				obs_data_set_string(settings, "css",
+					obs_data_get_string(req->data, "css"));
+			}
 
-            if (req->hasField("width")) {
-                obs_data_set_int(settings, "width",
-                    obs_data_get_int(req->data, "width"));
-            }
+			if (req->hasField("width")) {
+				obs_data_set_int(settings, "width",
+					obs_data_get_int(req->data, "width"));
+			}
 
-            if (req->hasField("height")) {
-                obs_data_set_int(settings, "height",
-                    obs_data_get_int(req->data, "height"));
-            }
+			if (req->hasField("height")) {
+				obs_data_set_int(settings, "height",
+					obs_data_get_int(req->data, "height"));
+			}
 
-            if (req->hasField("fps")) {
-                obs_data_set_int(settings, "fps",
-                    obs_data_get_int(req->data, "fps"));
-            }
+			if (req->hasField("fps")) {
+				obs_data_set_int(settings, "fps",
+					obs_data_get_int(req->data, "fps"));
+			}
 
-            obs_source_update(sceneItemSource, settings);
+			obs_source_update(sceneItemSource, settings);
 
-            if (req->hasField("render")) {
-                obs_sceneitem_set_visible(sceneItem,
-                    obs_data_get_bool(req->data, "render"));
-            }
+			if (req->hasField("render")) {
+				obs_sceneitem_set_visible(sceneItem,
+					obs_data_get_bool(req->data, "render"));
+			}
 
-            req->SendOKResponse();
-        } else {
-            req->SendErrorResponse("not browser source");
-        }
-    } else {
-        req->SendErrorResponse("specified scene item doesn't exist");
-    }
+			req->SendOKResponse();
+		}
+		else {
+			req->SendErrorResponse("not browser source");
+		}
+	}
+	else {
+		req->SendErrorResponse("specified scene item doesn't exist");
+	}
 }
 
 /**
@@ -978,26 +987,139 @@ void WSRequestHandler::HandleSetBrowserSourceProperties(WSRequestHandler* req) {
  * @category sources
  * @since 4.1.0
  */
- void WSRequestHandler::HandleGetSpecialSources(WSRequestHandler* req) {
-    OBSDataAutoRelease response = obs_data_create();
+void WSRequestHandler::HandleGetSpecialSources(WSRequestHandler* req) {
+	OBSDataAutoRelease response = obs_data_create();
 
-    QMap<const char*, int> sources;
-    sources["desktop-1"] = 1;
-    sources["desktop-2"] = 2;
-    sources["mic-1"] = 3;
-    sources["mic-2"] = 4;
-    sources["mic-3"] = 5;
+	QMap<const char*, int> sources;
+	sources["desktop-1"] = 1;
+	sources["desktop-2"] = 2;
+	sources["mic-1"] = 3;
+	sources["mic-2"] = 4;
+	sources["mic-3"] = 5;
 
-    QMapIterator<const char*, int> i(sources);
-    while (i.hasNext()) {
-        i.next();
+	QMapIterator<const char*, int> i(sources);
+	while (i.hasNext()) {
+		i.next();
 
-        const char* id = i.key();
-        OBSSourceAutoRelease source = obs_get_output_source(i.value());
-        if (source) {
-            obs_data_set_string(response, id, obs_source_get_name(source));
-        }
-    }
+		const char* id = i.key();
+		OBSSourceAutoRelease source = obs_get_output_source(i.value());
+		if (source) {
+			obs_data_set_string(response, id, obs_source_get_name(source));
+		}
+	}
 
-    req->SendOKResponse(response);
+	req->SendOKResponse(response);
+}
+
+void WSRequestHandler::HandleGetSourceTypeDefaults(WSRequestHandler* req) {
+	if (!req->hasField("source-type")) {
+		req->SendErrorResponse("source-type parameter is missing");
+		return;
+	}
+
+	OBSDataAutoRelease sourceDefaults = obs_get_source_defaults(obs_data_get_string(req->data, "source-type"));
+	OBSDataAutoRelease response = obs_data_create();
+
+	obs_data_set_string(response, "source-type", obs_data_get_string(req->data, "source-type"));
+	obs_data_set_obj(response, "settings", sourceDefaults);
+	req->SendOKResponse(response);
+}
+
+void WSRequestHandler::HandleAddNewSourceToScene(WSRequestHandler* req) {
+	if (!req->hasField("name")) {
+		req->SendErrorResponse("Source name must be specified");
+		return;
+	}
+
+	if (!req->hasField("type")) {
+		req->SendErrorResponse("Source type must be specified");
+		return;
+	}
+
+	if (!req->hasField("scene")) {
+		req->SendErrorResponse("Scene name must be specified");
+		return;
+	}
+
+	QString sceneName = obs_data_get_string(req->data, "scene");
+	obs_source_t *scene_src = obs_get_source_by_name(sceneName.toUtf8());
+	if (!scene_src) {
+		req->SendErrorResponse("Scene does not exist");
+		return;
+	}
+
+	obs_scene_t *scene = obs_scene_from_source(scene_src);
+	if (!scene) {
+		req->SendErrorResponse("Unable to find scene");
+		return;
+	}
+
+	if (!req->hasField("settings")) {
+		req->SendErrorResponse("Settings must be specified");
+		return;
+	}
+
+	OBSSourceAutoRelease src = obs_source_create(
+		obs_data_get_string(req->data, "type"),
+		obs_data_get_string(req->data, "name"),
+		obs_data_get_obj(req->data, "settings"),
+		NULL
+	);
+
+	if (!src) {
+		req->SendErrorResponse("Error occurred creating source");
+		return;
+	}
+
+	obs_sceneitem_t *item = obs_scene_add(scene, src);
+	if (!item) {
+		req->SendErrorResponse("Error adding source to scene");
+		return;
+	}
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "source", obs_data_get_string(req->data, "source"));
+	obs_data_set_string(response, "scene", obs_data_get_string(req->data, "scene"));
+
+	req->SendOKResponse(response);
+}
+
+void WSRequestHandler::HandleRemoveSourceFromScene(WSRequestHandler *req) {
+	if (!req->hasField("name")) {
+		req->SendErrorResponse("Source name must be specified");
+		return;
+	}
+
+	if (!req->hasField("scene")) {
+		req->SendErrorResponse("No scene specified");
+		return;
+	}
+
+	QString sceneName = obs_data_get_string(req->data, "scene");
+	obs_source_t *scene_src = obs_get_source_by_name(sceneName.toUtf8());
+	if (!scene_src) {
+		req->SendErrorResponse("Scene does not exist");
+		return;
+	}
+
+	obs_scene_t *scene = obs_scene_from_source(scene_src);
+	if (!scene) {
+		req->SendErrorResponse("Unable to find scene");
+		return;
+	}
+
+	QString sourceName = obs_data_get_string(req->data, "name");
+	obs_sceneitem_t *item = obs_scene_find_source(scene, sourceName.toUtf8());
+	if (!item) {
+		req->SendErrorResponse("Unable to find source in scene");
+		return;
+	}
+
+	obs_sceneitem_remove(item);
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "source", obs_data_get_string(req->data, "name"));
+	obs_data_set_string(response, "scene", obs_data_get_string(req->data, "scene"));
+
+	req->SendOKResponse(response);
 }


### PR DESCRIPTION
Websocket clients can now add a completely new video source to a scene, also remove a video source from a scene.
Pull request would be against master but master doesn't seem to work.