### PR TITLE
Add wget to install-dependencies-macos.sh

### DIFF
--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -11,5 +11,6 @@ brew install libav
 brew install qt5
 
 # Packages app
+brew install wget
 wget --quiet --retry-connrefused --waitretry=1 https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
 sudo installer -pkg ./Packages.pkg -target /


### PR DESCRIPTION
wget is not installed by default, so when doing the build on a fresh machine, brew install it first