### PR TITLE
CI: Fix QT 5.10 not building under macOS 10.13+

### DIFF
--- a/CI/macos/qt.rb
+++ b/CI/macos/qt.rb
@@ -18,7 +18,7 @@ class Qt < Formula
 
   option "with-docs", "Build documentation"
   option "with-examples", "Build examples"
-  
+
   deprecated_option "with-mysql" => "with-mysql-client"
 
   # OS X 10.7 Lion is still supported in Qt 5.5, but is no longer a reference
@@ -42,6 +42,23 @@ class Qt < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch"
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
+  end
+
+  # Fix compile error on macOS 10.13 around QFixed:
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67545
+  patch do
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/0de0e229/qt/QTBUG-67545.patch"
+    sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"
+  end
+
+  # Fix compile error on macOS 10.13 caused by qtlocation dependency
+  # mapbox-gl-native using Boost 1.62.0 does not build with C++ 17:
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67810
+  patch do
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/a1a1f0dd/qt/QTBUG-67810.patch"
+    sha256 "8ee0bf71df1043f08ebae3aa35036be29c4d9ebff8a27e3b0411a6bd635e9382"
   end
 
   # Remove for > 5.10.0
@@ -71,6 +88,7 @@ class Qt < Formula
       -no-rpath
       -pkg-config
       -dbus-runtime
+      -no-assimp
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"


### PR DESCRIPTION
As described by in https://github.com/Homebrew/homebrew-core/issues/27095, it is impossible to build QT 5.10 on any macOS newer than macOS 10.12 due to it using C++ 17 by default.

As explained in the issue, the changes outlined in https://github.com/Homebrew/homebrew-core/pull/27139 need to be applied to the Homebrew formula. With those QT 5.10 builds successfully and the result obs-websocket build at least loads without issue in OBS 22.0.3 under macOS 10.14.