### PR TITLE
4.4 macOS build system update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ matrix:
 
   - os: osx
     env: _macos_build
-    osx_image: xcode8.3
+    osx_image: xcode9.4
     before_install:
     - "./CI/install-dependencies-macos.sh"
     - "./CI/install-build-obs-macos.sh"
     script: "./CI/build-macos.sh"
-    after_success: 
+    after_success:
     - ./CI/package-macos.sh
 
 deploy:
@@ -53,7 +53,7 @@ deploy:
   acl: public_read
   on:
     repo: Palakis/obs-websocket
-    condition: 
+    condition:
     - "$TRAVIS_OS_NAME = linux"
     - "-d /home/travis/package"
     all_branches: true

--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
-set -ex
+if [[ "${OSTYPE}" != "darwin"* ]]; then
+    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    return 1
+fi
+
+HAS_CMAKE=$(type cmake 2>/dev/null)
+HAS_GIT=$(type git 2>/dev/null)
+
+if [[ "${HAS_CMAKE}" == "" ]]; then
+    echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."
+    return 1
+fi
 
 #export QT_PREFIX="$(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"
 
+echo "[obs-websocket] Building 'obs-websocket' for macOS."
 mkdir -p build && cd build
 cmake .. \
 	-DQTDIR=/usr/local/opt/qt \

--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -8,7 +8,6 @@ if [ "${OSTYPE}" != "Darwin" ]; then
 fi
 
 HAS_CMAKE=$(type cmake 2>/dev/null)
-HAS_GIT=$(type git 2>/dev/null)
 
 if [ "${HAS_CMAKE}" = "" ]; then
     echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."

--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -10,7 +10,7 @@ fi
 HAS_CMAKE=$(type cmake 2>/dev/null)
 HAS_GIT=$(type git 2>/dev/null)
 
-if [[ "${HAS_CMAKE}" == "" ]]; then
+if [ "${HAS_CMAKE}" = "" ]; then
     echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."
     exit 1
 fi

--- a/CI/build-macos.sh
+++ b/CI/build-macos.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-if [[ "${OSTYPE}" != "darwin"* ]]; then
+
+OSTYPE=$(uname)
+
+if [ "${OSTYPE}" != "Darwin" ]; then
     echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
-    return 1
+    exit 1
 fi
 
 HAS_CMAKE=$(type cmake 2>/dev/null)
@@ -9,7 +12,7 @@ HAS_GIT=$(type git 2>/dev/null)
 
 if [[ "${HAS_CMAKE}" == "" ]]; then
     echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."
-    return 1
+    exit 1
 fi
 
 #export QT_PREFIX="$(find /usr/local/Cellar/qt5 -d 1 | tail -n 1)"

--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -1,13 +1,31 @@
 #!/bin/sh
-set -ex
+if [[ "${OSTYPE}" != "darwin"* ]]; then
+    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    return 1
+fi
+
+HAS_CMAKE=$(type cmake 2>/dev/null)
+HAS_GIT=$(type git 2>/dev/null)
+
+if [[ "${HAS_CMAKE}" == "" ]]; then
+    echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."
+    return 1
+fi
+
+if [[ "${HAS_GIT}" == "" ]]; then
+    echo "[obs-websocket - Error] Git not installed - please install Xcode developer tools or via Homebrew."
+    return 1
+fi
 
 # Build obs-studio
 cd ..
+echo "[obs-websocket] Cloning obs-studio from GitHub.."
 git clone https://github.com/obsproject/obs-studio
 cd obs-studio
 OBSLatestTag=$(git describe --tags --abbrev=0)
 git checkout $OBSLatestTag
 mkdir build && cd build
+echo "[obs-websocket] Building obs-studio.."
 cmake .. \
 	-DDISABLE_PLUGINS=true \
 	-DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake \

--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -3,7 +3,7 @@
 OSTYPE=$(uname)
 
 if [ "${OSTYPE}" != "Darwin" ]; then
-    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    echo "[obs-websocket - Error] macOS obs-studio build script can be run on Darwin-type OS only."
     exit 1
 fi
 

--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -10,12 +10,12 @@ fi
 HAS_CMAKE=$(type cmake 2>/dev/null)
 HAS_GIT=$(type git 2>/dev/null)
 
-if [ "${HAS_CMAKE}" == "" ]; then
+if [ "${HAS_CMAKE}" = "" ]; then
     echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."
     exit 1
 fi
 
-if [ "${HAS_GIT}" == "" ]; then
+if [ "${HAS_GIT}" = "" ]; then
     echo "[obs-websocket - Error] Git not installed - please install Xcode developer tools or via Homebrew."
     exit 1
 fi

--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -1,20 +1,23 @@
 #!/bin/sh
-if [[ "${OSTYPE}" != "darwin"* ]]; then
+
+OSTYPE=$(uname)
+
+if [ "${OSTYPE}" != "Darwin" ]; then
     echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
-    return 1
+    exit 1
 fi
 
 HAS_CMAKE=$(type cmake 2>/dev/null)
 HAS_GIT=$(type git 2>/dev/null)
 
-if [[ "${HAS_CMAKE}" == "" ]]; then
+if [ "${HAS_CMAKE}" == "" ]; then
     echo "[obs-websocket - Error] CMake not installed - please run 'install-dependencies-macos.sh' first."
-    return 1
+    exit 1
 fi
 
-if [[ "${HAS_GIT}" == "" ]]; then
+if [ "${HAS_GIT}" == "" ]; then
     echo "[obs-websocket - Error] Git not installed - please install Xcode developer tools or via Homebrew."
-    return 1
+    exit 1
 fi
 
 # Build obs-studio

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
-if [[ "${OSTYPE}" != "darwin"* ]]; then
+
+OSTYPE=$(uname)
+
+if [ "${OSTYPE}" != "Darwin" ]; then
     echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
-    return 1
+    exit 1
 fi
 
 HAS_BREW=$(type brew 2>/dev/null)
 
 if [[ "${HAS_BREW}" == "" ]]; then
     echo "[obs-websocket - Error] Please install Homebrew (https://www.brew.sh/) to build obs-websocket on macOS."
-    return 1
+    exit 1
 fi
 
 # OBS Studio deps

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -1,16 +1,52 @@
 #!/bin/sh
-set -ex
+if [[ "${OSTYPE}" != "darwin"* ]]; then
+    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    return 1
+fi
+
+HAS_BREW=$(type brew 2>/dev/null)
+
+if [[ "${HAS_BREW}" == "" ]]; then
+    echo "[obs-websocket - Error] Please install Homebrew (https://www.brew.sh/) to build obs-websocket on macOS."
+    return 1
+fi
 
 # OBS Studio deps
+echo "[obs-websocket] Updating Homebrew formulas.."
 brew update
-brew install ffmpeg
-brew install libav
+echo "[obs-websocket] Checking installed Homebrew formulas.."
+BREW_PACKAGES=$(brew list)
+BREW_DEPENDENCIES="ffmpeg libav cmake"
+
+for DEPENDENCY in ${BREW_DEPENDENCIES}; do
+    if echo ${BREW_PACKAGES} | grep -q "^${DEPENDENCY}\$"; then
+        echo "[obs-websocket] Installing OBS-Studio dependency '${DEPENDENCY}'.."
+        brew install ${DEPENDENCY} 2>/dev/null
+    else
+        echo "[obs-websocket] Upgrading OBS-Studio dependency '${DEPENDENCY}'.."
+        brew upgrade ${DEPENDENCY} 2>/dev/null
+    fi
+done
 
 # qtwebsockets deps
-# qt latest
-brew install ./CI/macos/qt.rb
+echo "[obs-websocket] Installing obs-websocket dependency 'QT 5.10.1'.."
+# =!= NOTICE =!=
+# When building QT5 from sources on macOS 10.13+, use local qt5 formula:
+# brew install ./CI/macos/qt.rb
+# Pouring from the bottle is much quicker though, so use bottle for now.
+# =!= NOTICE =!=
 
-# Packages app
-brew install wget || brew upgrade wget
-wget --quiet --retry-connrefused --waitretry=1 https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/9a70413d137839de0054571e5f85fd07ee400955/Formula/qt.rb 2>/dev/null
+
+# Pin this version of QT5 to avoid `brew upgrade`
+# upgrading it to incompatible version
+brew pin qt 2>/dev/null
+
+# Fetch and install Packages app
+# =!= NOTICE =!=
+# Installs a LaunchDaemon under /Library/LaunchDaemons/fr.whitebox.packages.build.dispatcher.plist
+# =!= NOTICE =!=
+
+echo "[obs-websocket] Installing Packaging app (might require password due to 'sudo').."
+curl -o './Packages.pkg' --retry-connrefused -s --retry-delay 1 'https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg'
 sudo installer -pkg ./Packages.pkg -target /

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -9,7 +9,7 @@ fi
 
 HAS_BREW=$(type brew 2>/dev/null)
 
-if [[ "${HAS_BREW}" == "" ]]; then
+if [ "${HAS_BREW}" = "" ]; then
     echo "[obs-websocket - Error] Please install Homebrew (https://www.brew.sh/) to build obs-websocket on macOS."
     exit 1
 fi

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -3,7 +3,7 @@
 OSTYPE=$(uname)
 
 if [ "${OSTYPE}" != "Darwin" ]; then
-    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    echo "[obs-websocket - Error] macOS install dependencies script can be run on Darwin-type OS only."
     exit 1
 fi
 

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -39,11 +39,11 @@ echo "[obs-websocket] Installing obs-websocket dependency 'QT 5.10.1'.."
 # Pouring from the bottle is much quicker though, so use bottle for now.
 # =!= NOTICE =!=
 
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/9a70413d137839de0054571e5f85fd07ee400955/Formula/qt.rb 2>/dev/null
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/9a70413d137839de0054571e5f85fd07ee400955/Formula/qt.rb
 
 # Pin this version of QT5 to avoid `brew upgrade`
 # upgrading it to incompatible version
-brew pin qt 2>/dev/null
+brew pin qt
 
 # Fetch and install Packages app
 # =!= NOTICE =!=

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -22,12 +22,12 @@ BREW_PACKAGES=$(brew list)
 BREW_DEPENDENCIES="ffmpeg libav cmake"
 
 for DEPENDENCY in ${BREW_DEPENDENCIES}; do
-    if echo ${BREW_PACKAGES} | grep -q "^${DEPENDENCY}\$"; then
-        echo "[obs-websocket] Installing OBS-Studio dependency '${DEPENDENCY}'.."
-        brew install ${DEPENDENCY} 2>/dev/null
-    else
+    if echo "${BREW_PACKAGES}" | grep -q "^${DEPENDENCY}\$"; then
         echo "[obs-websocket] Upgrading OBS-Studio dependency '${DEPENDENCY}'.."
         brew upgrade ${DEPENDENCY} 2>/dev/null
+    else
+        echo "[obs-websocket] Installing OBS-Studio dependency '${DEPENDENCY}'.."
+        brew install ${DEPENDENCY} 2>/dev/null
     fi
 done
 

--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -15,8 +15,8 @@ if [ "${HAS_BREW}" = "" ]; then
 fi
 
 # OBS Studio deps
-echo "[obs-websocket] Updating Homebrew formulas.."
-brew update
+echo "[obs-websocket] Updating Homebrew.."
+brew update >/dev/null
 echo "[obs-websocket] Checking installed Homebrew formulas.."
 BREW_PACKAGES=$(brew list)
 BREW_DEPENDENCIES="ffmpeg libav cmake"

--- a/CI/macos/qt.rb
+++ b/CI/macos/qt.rb
@@ -3,15 +3,15 @@
 class Qt < Formula
 	desc "Cross-platform application and UI framework"
 	homepage "https://www.qt.io/"
-	url "https://download.qt.io/official_releases/qt/5.10/5.10.0/single/qt-everywhere-src-5.10.0.tar.xz"
-	mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.10/5.10.0/single/qt-everywhere-opensource-src-5.10.0.tar.xz"
-	sha256 "936d4cf5d577298f4f9fdb220e85b008ae321554a5fcd38072dc327a7296230e"
-	head "https://code.qt.io/qt/qt5.git", :branch => "5.10", :shallow => false
+	url "https://download.qt.io/archive/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz"
+	mirror "https://mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz"
+	sha256 "05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a"
+	head "https://code.qt.io/qt/qt5.git", :branch => "5.10.1", :shallow => false
 
 	bottle do
-		sha256 "332ab2f3eb7c13510f460c13d28a562db03297149a3615feb9e3d467fafde56c" => :high_sierra
-		sha256 "c93cf6ead1774cfa7a369c92c7d6a69154bc0dd5b48a0e7ddf3a78202c4a3dc5" => :sierra
-		sha256 "44425e23d8b9c2b8b2f50d850ca94dcd411cd89e20e057c8d6505c9056d06328" => :el_capitan
+		sha256 "8b4bad005596a5f8790150fe455db998ac2406f4e0f04140d6656205d844d266" => :high_sierra
+		sha256 "9c488554935fb573554a4e36d36d3c81e47245b7fefc4b61edef894e67ba1740" => :sierra
+		sha256 "c0407afba5951df6cc4c6f6c1c315972bd41c99cecb4e029919c4c15ab6f7bdc" => :el_capitan
 	end
 
 	keg_only "Qt 5 has CMake issues when linked"
@@ -59,18 +59,6 @@ class Qt < Formula
 	patch do
 		url "https://raw.githubusercontent.com/z00m1n/formula-patches/a1a1f0dd/qt/QTBUG-67810.patch"
 		sha256 "8ee0bf71df1043f08ebae3aa35036be29c4d9ebff8a27e3b0411a6bd635e9382"
-	end
-
-	# Remove for > 5.10.0
-	# Fix "error: 'loadFileURL:allowingReadAccessToURL:' is only available on
-	# macOS 10.11 or newer [-Werror,-Wunguarded-availability]"
-	# Reported 8 Dec 2017 https://bugreports.qt.io/browse/QTBUG-65075
-	# Equivalent to upstream fix from 8 Dec 2017 https://codereview.qt-project.org/#/c/213993/
-	if MacOS::Xcode.version >= "9.0"
-		patch do
-			url "https://raw.githubusercontent.com/Homebrew/formula-patches/9c97726e2b153099049326ade23fe24b52b778fe/qt/QTBUG-65075.diff"
-			sha256 "a51595868c6173ab53463107e0ee3355576002c32ab80897587c3607589cfd22"
-		end
 	end
 
 	def install

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-echo "-- Preparing package build"
-export QT_CELLAR_PREFIX="$(find /usr/local/Cellar/qt -d 1 | sort -t '.' -k 1,1n -k 2,2n -k 3,3n | tail -n 1)"
+echo "[obs-websocket] Preparing package build"
+export QT_CELLAR_PREFIX="$(/usr/bin/find /usr/local/Cellar/qt -d 1 | sort -t '.' -k 1,1n -k 2,2n -k 3,3n | tail -n 1)"
 
 export WS_LIB="/usr/local/opt/qt/lib/QtWebSockets.framework/QtWebSockets"
 export NET_LIB="/usr/local/opt/qt/lib/QtNetwork.framework/QtNetwork"
@@ -20,20 +20,20 @@ fi
 export FILENAME="obs-websocket-$VERSION.pkg"
 export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
-echo "-- Copying Qt dependencies"
+echo "[obs-websocket] Copying Qt dependencies"
 if [ ! -f ./build/$(basename $WS_LIB) ]; then cp $WS_LIB ./build; fi
 if [ ! -f ./build/$(basename $NET_LIB) ]; then cp $NET_LIB ./build; fi
 
 chmod +rw ./build/QtWebSockets ./build/QtNetwork
 
-echo "-- Modifying QtNetwork"
+echo "[obs-websocket] Modifying QtNetwork"
 install_name_tool \
 	-id @rpath/QtNetwork \
 	-change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork @rpath/QtNetwork \
 	-change $QT_CELLAR_PREFIX/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \
 	./build/QtNetwork
 
-echo "-- Modifying QtWebSockets"
+echo "[obs-websocket] Modifying QtWebSockets"
 install_name_tool \
 	-id @rpath/QtWebSockets \
 	-change /usr/local/opt/qt/lib/QtWebSockets.framework/Versions/5/QtWebSockets @rpath/QtWebSockets \
@@ -41,7 +41,7 @@ install_name_tool \
 	-change $QT_CELLAR_PREFIX/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \
 	./build/QtWebSockets
 
-echo "-- Modifying obs-websocket.so"
+echo "[obs-websocket] Modifying obs-websocket.so"
 install_name_tool \
 	-change /usr/local/opt/qt/lib/QtWebSockets.framework/Versions/5/QtWebSockets @rpath/QtWebSockets \
 	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @rpath/QtWidgets \
@@ -51,18 +51,18 @@ install_name_tool \
 	./build/obs-websocket.so
 
 # Check if replacement worked
-echo "-- Dependencies for QtNetwork"
+echo "[obs-websocket] Dependencies for QtNetwork"
 otool -L ./build/QtNetwork
-echo "-- Dependencies for QtWebSockets"
+echo "[obs-websocket] Dependencies for QtWebSockets"
 otool -L ./build/QtWebSockets
-echo "-- Dependencies for obs-websocket"
+echo "[obs-websocket] Dependencies for obs-websocket"
 otool -L ./build/obs-websocket.so
 
 chmod -w ./build/QtWebSockets ./build/QtNetwork
 
-echo "-- Actual package build"
+echo "[obs-websocket] Actual package build"
 packagesbuild ./CI/macos/obs-websocket.pkgproj
 
-echo "-- Renaming obs-websocket.pkg to $FILENAME"
+echo "[obs-websocket] Renaming obs-websocket.pkg to $FILENAME"
 mv ./release/obs-websocket.pkg ./release/$FILENAME
 cp ./release/$FILENAME ./release/$LATEST_FILENAME

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-if [[ "${OSTYPE}" != "darwin"* ]]; then
+OSTYPE=$(uname)
+
+if [ "${OSTYPE}" != "Darwin" ]; then
     echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
-    return 1
+    exit 1
 fi
 
 echo "[obs-websocket] Preparing package build"

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ "${OSTYPE}" != "darwin"* ]]; then
+    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    return 1
+fi
+
 echo "[obs-websocket] Preparing package build"
 export QT_CELLAR_PREFIX="$(/usr/bin/find /usr/local/Cellar/qt -d 1 | sort -t '.' -k 1,1n -k 2,2n -k 3,3n | tail -n 1)"
 

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -5,7 +5,7 @@ set -e
 OSTYPE=$(uname)
 
 if [ "${OSTYPE}" != "Darwin" ]; then
-    echo "[obs-websocket - Error] macOS build script can be run on Darwin-type OS only."
+    echo "[obs-websocket - Error] macOS package script can be run on Darwin-type OS only."
     exit 1
 fi
 


### PR DESCRIPTION
As discussed in https://github.com/Palakis/obs-websocket/issues/238 this PR updates the build scripts for macOS.

I added some dependency checks and cleaned-up Homebrew handling. The build-files also use the same QT build as obs-studio itself (checked their CI scripts, they install from the same remote formula). This speeds up building (as QT is "poured from a bottle") and ensures compatibility - for now.

I've also updated the bundled QT5 formula to match the remote one, but also added the necessary patches to make it build on macOS 10.13+.

Additionally the scripts now "pin" qt to the installed version, to avoid `brew upgrade` from upgrading it to 5.12.