### PR TITLE
general: Fix several typos throughout

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -657,7 +657,7 @@ void WSEvents::StreamStatus() {
 /**
  * Emitted every 2 seconds after enabling it by calling SetHeartbeat.
  *
- * @return {boolean} `pulse` Toggles between every JSON meassage as an "I am alive" indicator.
+ * @return {boolean} `pulse` Toggles between every JSON message as an "I am alive" indicator.
  * @return {string (optional)} `current-profile` Current active profile.
  * @return {string (optional)} `current-scene` Current active scene.
  * @return {boolean (optional)} `streaming` Current streaming state.

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -322,7 +322,7 @@ void WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler* req) {
 /**
 * Reset a scene item.
 *
-* @param {String (optional)} `scene-name` Name of the scene the source belogns to. Defaults to the current scene.
+* @param {String (optional)} `scene-name` Name of the scene the source belongs to. Defaults to the current scene.
 * @param {String} `item` Name of the source item.
 *
 * @api requests

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -227,7 +227,7 @@ void WSRequestHandler::HandleGetVolume(WSRequestHandler* req) {
 */
 void WSRequestHandler::HandleGetMute(WSRequestHandler* req) {
 	if (!req->hasField("source")) {
-		req->SendErrorResponse("mssing request parameters");
+		req->SendErrorResponse("missing request parameters");
 		return;
 	}
 
@@ -264,7 +264,7 @@ void WSRequestHandler::HandleGetMute(WSRequestHandler* req) {
 void WSRequestHandler::HandleSetMute(WSRequestHandler* req) {
 	if (!req->hasField("source") ||
 		!req->hasField("mute")) {
-		req->SendErrorResponse("mssing request parameters");
+		req->SendErrorResponse("missing request parameters");
 		return;
 	}
 
@@ -967,7 +967,7 @@ void WSRequestHandler::HandleSetBrowserSourceProperties(WSRequestHandler* req) {
 /**
  * Deletes a scene item.
  *
- * @param {String (optional)} `scene` Name of the scene the source belogns to. Defaults to the current scene.
+ * @param {String (optional)} `scene` Name of the scene the source belongs to. Defaults to the current scene.
  * @param {Object} `item` item to delete (required)
  * @param {String} `item.name` name of the scene item (prefer `id`, including both is acceptable).
  * @param {int} `item.id` id of the scene item.
@@ -1065,7 +1065,7 @@ void WSRequestHandler::HandleDuplicateSceneItem(WSRequestHandler* req) {
 	obs_sceneitem_t *newItem = data.newItem;
 
 	if (!newItem) {
-		req->SendErrorResponse("Error duplicating scenee item");
+		req->SendErrorResponse("Error duplicating scene item");
 	}
 	OBSDataAutoRelease responseData = obs_data_create();
 	OBSDataAutoRelease itemData = obs_data_create();

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -252,7 +252,7 @@ void WSRequestHandler::HandleStopStreaming(WSRequestHandler* req) {
  * @return {Object} `settings` Stream settings object.
  * @return {String} `settings.server` The publish URL.
  * @return {String} `settings.key` The publish key of the stream.
- * @return {boolean} `settings.use-auth` Indicates whether audentication should be used when connecting to the streaming server.
+ * @return {boolean} `settings.use-auth` Indicates whether authentication should be used when connecting to the streaming server.
  * @return {String} `settings.username` The username to use when accessing the streaming server. Only present if `use-auth` is `true`.
  * @return {String} `settings.password` The password to use when accessing the streaming server. Only present if `use-auth` is `true`.
  *


### PR DESCRIPTION
Fixed several typos throughout the project on the 4.3-maintenance branch.

This mostly the same as #247, but GitHub said the PR for one branch could not be automatically merged into the other, so I'm filing a separate PR so you don't have to do the legwork.