### PR TITLE
Fix compile error and added dependency check in build script

### DIFF
--- a/CI/install-dependencies-macos.sh
+++ b/CI/install-dependencies-macos.sh
@@ -50,6 +50,10 @@ brew pin qt
 # Installs a LaunchDaemon under /Library/LaunchDaemons/fr.whitebox.packages.build.dispatcher.plist
 # =!= NOTICE =!=
 
-echo "[obs-websocket] Installing Packaging app (might require password due to 'sudo').."
-curl -o './Packages.pkg' --retry-connrefused -s --retry-delay 1 'https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg'
-sudo installer -pkg ./Packages.pkg -target /
+HAS_PACKAGES=$(type packagesbuild 2>/dev/null)
+
+if [ "${HAS_PACKAGES}" = "" ]; then
+    echo "[obs-websocket] Installing Packaging app (might require password due to 'sudo').."
+    curl -o './Packages.pkg' --retry-connrefused -s --retry-delay 1 'https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg'
+    sudo installer -pkg ./Packages.pkg -target /
+fi


### PR DESCRIPTION
Just two quick fixes I made while building a package today:

* Added a missing comma to get the project to compile again
* Added a check for already-installed `packagesbuild` in the CI script for macOS dependencies