### PR TITLE
Support item_transform signal

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -553,3 +553,77 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
 	config_save(profile);
 	return true;
 }
+
+obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
+	OBSDataAutoRelease data = obs_data_create();
+
+	OBSDataAutoRelease posData = obs_data_create();
+	vec2 pos;
+	obs_sceneitem_get_pos(sceneItem, &pos);
+	obs_data_set_double(posData, "x", pos.x);
+	obs_data_set_double(posData, "y", pos.y);
+	obs_data_set_int(posData, "alignment", obs_sceneitem_get_alignment(sceneItem));
+	obs_data_set_obj(data, "position", posData);
+
+	obs_data_set_double(data, "rotation", obs_sceneitem_get_rot(sceneItem));
+
+	OBSDataAutoRelease scaleData = obs_data_create();
+	vec2 scale;
+	obs_sceneitem_get_scale(sceneItem, &scale);
+	obs_data_set_double(scaleData, "x", scale.x);
+	obs_data_set_double(scaleData, "y", scale.y);
+	obs_data_set_obj(data, "scale", scaleData);
+
+	OBSDataAutoRelease cropData = obs_data_create();
+	obs_sceneitem_crop crop;
+	obs_sceneitem_get_crop(sceneItem, &crop);
+	obs_data_set_int(cropData, "left", crop.left);
+	obs_data_set_int(cropData, "top", crop.top);
+	obs_data_set_int(cropData, "right", crop.right);
+	obs_data_set_int(cropData, "bottom", crop.bottom);
+	obs_data_set_obj(data, "crop", cropData);
+
+	obs_data_set_bool(data, "visible", obs_sceneitem_visible(sceneItem));
+
+	OBSDataAutoRelease boundsData = obs_data_create();
+	obs_bounds_type boundsType = obs_sceneitem_get_bounds_type(sceneItem);
+	if (boundsType == OBS_BOUNDS_NONE) {
+		obs_data_set_string(boundsData, "type", "OBS_BOUNDS_NONE");
+	}
+	else {
+		switch (boundsType) {
+		case OBS_BOUNDS_STRETCH: {
+			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_STRETCH");
+			break;
+		}
+		case OBS_BOUNDS_SCALE_INNER: {
+			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_INNER");
+			break;
+		}
+		case OBS_BOUNDS_SCALE_OUTER: {
+			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_OUTER");
+			break;
+		}
+		case OBS_BOUNDS_SCALE_TO_WIDTH: {
+			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_WIDTH");
+			break;
+		}
+		case OBS_BOUNDS_SCALE_TO_HEIGHT: {
+			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_HEIGHT");
+			break;
+		}
+		case OBS_BOUNDS_MAX_ONLY: {
+			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_MAX_ONLY");
+			break;
+		}
+		}
+		obs_data_set_int(boundsData, "alignment", obs_sceneitem_get_bounds_alignment(sceneItem));
+		vec2 bounds;
+		obs_sceneitem_get_bounds(sceneItem, &bounds);
+		obs_data_set_double(boundsData, "x", bounds.x);
+		obs_data_set_double(boundsData, "y", bounds.y);
+	}
+	obs_data_set_obj(data, "bounds", boundsData);
+
+	return data;
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -555,7 +555,7 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
 }
 
 obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
-	OBSDataAutoRelease data = obs_data_create();
+	obs_data_t* data = obs_data_create();
 
 	OBSDataAutoRelease posData = obs_data_create();
 	vec2 pos;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -592,30 +592,30 @@ obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
 	}
 	else {
 		switch (boundsType) {
-		case OBS_BOUNDS_STRETCH: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_STRETCH");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_INNER: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_INNER");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_OUTER: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_OUTER");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_TO_WIDTH: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_WIDTH");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_TO_HEIGHT: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_HEIGHT");
-			break;
-		}
-		case OBS_BOUNDS_MAX_ONLY: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_MAX_ONLY");
-			break;
-		}
+			case OBS_BOUNDS_STRETCH: {
+				obs_data_set_string(boundsData, "type", "OBS_BOUNDS_STRETCH");
+				break;
+			}
+			case OBS_BOUNDS_SCALE_INNER: {
+				obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_INNER");
+				break;
+			}
+			case OBS_BOUNDS_SCALE_OUTER: {
+				obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_OUTER");
+				break;
+			}
+			case OBS_BOUNDS_SCALE_TO_WIDTH: {
+				obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_WIDTH");
+				break;
+			}
+			case OBS_BOUNDS_SCALE_TO_HEIGHT: {
+				obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_HEIGHT");
+				break;
+			}
+			case OBS_BOUNDS_MAX_ONLY: {
+				obs_data_set_string(boundsData, "type", "OBS_BOUNDS_MAX_ONLY");
+				break;
+			}
 		}
 		obs_data_set_int(boundsData, "alignment", obs_sceneitem_get_bounds_alignment(sceneItem));
 		vec2 bounds;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -41,6 +41,7 @@ class Utils {
 	static obs_sceneitem_t* GetSceneItemFromItem(obs_source_t* source, obs_data_t* item);
 	static obs_source_t* GetTransitionFromName(QString transitionName);
 	static obs_source_t* GetSceneFromNameOrCurrent(QString sceneName);
+	static obs_data_t* GetSceneItemPropertiesData(obs_sceneitem_t* item);
 
 	static bool IsValidAlignment(const uint32_t alignment);
 

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -940,77 +940,9 @@ void WSEvents::OnSceneItemTransform(void* param, calldata_t* data) {
 	const char* sceneItemName =
 		obs_source_get_name(obs_sceneitem_get_source(sceneItem));
 
-	OBSDataAutoRelease fields = obs_data_create();
+	OBSDataAutoRelease fields = Utils::GetSceneItemPropertiesData(sceneItem);
 	obs_data_set_string(fields, "scene-name", sceneName);
 	obs_data_set_string(fields, "item-name", sceneItemName);
-
-	OBSDataAutoRelease posData = obs_data_create();
-	vec2 pos;
-	obs_sceneitem_get_pos(sceneItem, &pos);
-	obs_data_set_double(posData, "x", pos.x);
-	obs_data_set_double(posData, "y", pos.y);
-	obs_data_set_int(posData, "alignment", obs_sceneitem_get_alignment(sceneItem));
-	obs_data_set_obj(fields, "position", posData);
-
-	obs_data_set_double(fields, "rotation", obs_sceneitem_get_rot(sceneItem));
-
-	OBSDataAutoRelease scaleData = obs_data_create();
-	vec2 scale;
-	obs_sceneitem_get_scale(sceneItem, &scale);
-	obs_data_set_double(scaleData, "x", scale.x);
-	obs_data_set_double(scaleData, "y", scale.y);
-	obs_data_set_obj(fields, "scale", scaleData);
-
-	OBSDataAutoRelease cropData = obs_data_create();
-	obs_sceneitem_crop crop;
-	obs_sceneitem_get_crop(sceneItem, &crop);
-	obs_data_set_int(cropData, "left", crop.left);
-	obs_data_set_int(cropData, "top", crop.top);
-	obs_data_set_int(cropData, "right", crop.right);
-	obs_data_set_int(cropData, "bottom", crop.bottom);
-	obs_data_set_obj(fields, "crop", cropData);
-
-	obs_data_set_bool(fields, "visible", obs_sceneitem_visible(sceneItem));
-
-	OBSDataAutoRelease boundsData = obs_data_create();
-	obs_bounds_type boundsType = obs_sceneitem_get_bounds_type(sceneItem);
-	if (boundsType == OBS_BOUNDS_NONE) {
-		obs_data_set_string(boundsData, "type", "OBS_BOUNDS_NONE");
-	}
-	else {
-		switch (boundsType) {
-		case OBS_BOUNDS_STRETCH: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_STRETCH");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_INNER: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_INNER");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_OUTER: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_OUTER");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_TO_WIDTH: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_WIDTH");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_TO_HEIGHT: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_HEIGHT");
-			break;
-		}
-		case OBS_BOUNDS_MAX_ONLY: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_MAX_ONLY");
-			break;
-		}
-		}
-		obs_data_set_int(boundsData, "alignment", obs_sceneitem_get_bounds_alignment(sceneItem));
-		vec2 bounds;
-		obs_sceneitem_get_bounds(sceneItem, &bounds);
-		obs_data_set_double(boundsData, "x", bounds.x);
-		obs_data_set_double(boundsData, "y", bounds.y);
-	}
-	obs_data_set_obj(fields, "bounds", boundsData);
 
 	instance->broadcastUpdate("SceneItemTransformChanged", fields);
 }

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -274,7 +274,7 @@ void WSEvents::connectSceneSignals(obs_source_t* scene) {
 		signal_handler_connect(sh,
 			"item_visible", OnSceneItemVisibilityChanged, this);
 		signal_handler_connect(sh,
-			"item_transform ", OnSceneItemTransform, this);
+			"item_transform", OnSceneItemTransform, this);
 	}
 }
 

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -256,6 +256,8 @@ void WSEvents::connectSceneSignals(obs_source_t* scene) {
 			"item_remove", OnSceneItemDelete, this);
 		signal_handler_disconnect(sh,
 			"item_visible", OnSceneItemVisibilityChanged, this);
+		signal_handler_disconnect(sh,
+			"item_transform", OnSceneItemTransform, this);
 	}
 
 	currentScene = scene;
@@ -271,6 +273,8 @@ void WSEvents::connectSceneSignals(obs_source_t* scene) {
 			"item_remove", OnSceneItemDelete, this);
 		signal_handler_connect(sh,
 			"item_visible", OnSceneItemVisibilityChanged, this);
+		signal_handler_connect(sh,
+			"item_transform ", OnSceneItemTransform, this);
 	}
 }
 
@@ -909,6 +913,38 @@ void WSEvents::OnSceneItemVisibilityChanged(void* param, calldata_t* data) {
 	obs_data_set_bool(fields, "item-visible", visible);
 
 	instance->broadcastUpdate("SceneItemVisibilityChanged", fields);
+}
+
+/**
+ * An item's transfrom has been changed.
+ *
+ * @return {String} `scene-name` Name of the scene.
+ * @return {String} `item-name` Name of the item in the scene.
+ *
+ * @api events
+ * @name OnSceneItemTransform
+ * @category sources
+ * @since 4.5.1
+ */
+void WSEvents::OnSceneItemTransform(void* param, calldata_t* data) {
+	WSEvents* instance = static_cast<WSEvents*>(param);
+
+	obs_scene_t* scene = nullptr;
+	calldata_get_ptr(data, "scene", &scene);
+
+	obs_sceneitem_t* sceneItem = nullptr;
+	calldata_get_ptr(data, "item", &sceneItem);
+
+	const char* sceneName =
+		obs_source_get_name(obs_scene_get_source(scene));
+	const char* sceneItemName =
+		obs_source_get_name(obs_sceneitem_get_source(sceneItem));
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "scene-name", sceneName);
+	obs_data_set_string(fields, "item-name", sceneItemName);
+
+	instance->broadcastUpdate("SourceItemChanged", fields);
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -922,7 +922,7 @@ void WSEvents::OnSceneItemVisibilityChanged(void* param, calldata_t* data) {
  * @return {String} `item-name` Name of the item in the scene.
  *
  * @api events
- * @name OnSceneItemTransform
+ * @name SourceItemChanged
  * @category sources
  * @since 4.5.1
  */

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -920,6 +920,7 @@ void WSEvents::OnSceneItemVisibilityChanged(void* param, calldata_t* data) {
  *
  * @return {String} `scene-name` Name of the scene.
  * @return {String} `item-name` Name of the item in the scene.
+ * @return {SceneItemProperties} `transform` Scene item transform properties
  *
  * @api events
  * @name SceneItemTransformChanged
@@ -940,9 +941,12 @@ void WSEvents::OnSceneItemTransform(void* param, calldata_t* data) {
 	const char* sceneItemName =
 		obs_source_get_name(obs_sceneitem_get_source(sceneItem));
 
-	OBSDataAutoRelease fields = Utils::GetSceneItemPropertiesData(sceneItem);
+	OBSDataAutoRelease transform = Utils::GetSceneItemPropertiesData(sceneItem);
+
+	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "scene-name", sceneName);
 	obs_data_set_string(fields, "item-name", sceneItemName);
+	obs_data_set_obj(fields, "transform", transform);
 
 	instance->broadcastUpdate("SceneItemTransformChanged", fields);
 }

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -116,4 +116,5 @@ private:
 	static void OnSceneItemAdd(void* param, calldata_t* data);
 	static void OnSceneItemDelete(void* param, calldata_t* data);
 	static void OnSceneItemVisibilityChanged(void* param, calldata_t* data);
+	static void OnSceneItemTransform(void* param, calldata_t* data);
 };

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -21,7 +21,7 @@
 * @return {int} `crop.bottom` The number of pixels cropped off the bottom of the source before scaling.
 * @return {int} `crop.left` The number of pixels cropped off the left of the source before scaling.
 * @return {bool} `visible` If the source is visible.
-* @return {String} `bounds.type` Type of bounding box.
+* @return {String} `bounds.type` Type of bounding box. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE".
 * @return {int} `bounds.alignment` Alignment of the bounding box.
 * @return {double} `bounds.x` Width of the bounding box.
 * @return {double} `bounds.y` Height of the bounding box.
@@ -75,7 +75,7 @@ HandlerResponse WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler*
 * @param {int} `crop.left` The new amount of pixels cropped off the left of the source before scaling.
 * @param {int} `crop.right` The new amount of pixels cropped off the right of the source before scaling.
 * @param {bool} `visible` The new visibility of the source. 'true' shows source, 'false' hides source.
-* @param {String} `bounds.type` The new bounds type of the source.
+* @param {String} `bounds.type` The new bounds type of the source. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE".
 * @param {int} `bounds.alignment` The new alignment of the bounding box. (0-2, 4-6, 8-10)
 * @param {double} `bounds.x` The new width of the bounding box.
 * @param {double} `bounds.y` The new height of the bounding box.
@@ -238,7 +238,7 @@ HandlerResponse WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler*
 	if (badRequest) {
 		return req->SendErrorResponse(errorMessage);
 	}
-	
+
 	return req->SendOKResponse();
 }
 
@@ -363,7 +363,7 @@ HandlerResponse WSRequestHandler::HandleSetSceneItemPosition(WSRequestHandler* r
 	if (!sceneItem) {
 		return req->SendErrorResponse("specified scene item doesn't exist");
 	}
-	
+
 	vec2 item_position = { 0 };
 	item_position.x = obs_data_get_double(req->data, "x");
 	item_position.y = obs_data_get_double(req->data, "y");
@@ -530,7 +530,7 @@ static void DuplicateSceneItem(void *_data, obs_scene_t *scene) {
  * @return {Object} `item` New item info
  * @return {int} `̀item.id` New item ID
  * @return {String} `item.name` New item name
- * 
+ *
  * @api requests
  * @name DuplicateSceneItem
  * @category scene items

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -53,76 +53,8 @@ HandlerResponse WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler*
 		return req->SendErrorResponse("specified scene item doesn't exist");
 	}
 
-	OBSDataAutoRelease data = obs_data_create();
+	OBSDataAutoRelease data = Utils::GetSceneItemPropertiesData(sceneItem);
 	obs_data_set_string(data, "name", itemName.toUtf8());
-
-	OBSDataAutoRelease posData = obs_data_create();
-	vec2 pos;
-	obs_sceneitem_get_pos(sceneItem, &pos);
-	obs_data_set_double(posData, "x", pos.x);
-	obs_data_set_double(posData, "y", pos.y);
-	obs_data_set_int(posData, "alignment", obs_sceneitem_get_alignment(sceneItem));
-	obs_data_set_obj(data, "position", posData);
-
-	obs_data_set_double(data, "rotation", obs_sceneitem_get_rot(sceneItem));
-
-	OBSDataAutoRelease scaleData = obs_data_create();
-	vec2 scale;
-	obs_sceneitem_get_scale(sceneItem, &scale);
-	obs_data_set_double(scaleData, "x", scale.x);
-	obs_data_set_double(scaleData, "y", scale.y);
-	obs_data_set_obj(data, "scale", scaleData);
-
-	OBSDataAutoRelease cropData = obs_data_create();
-	obs_sceneitem_crop crop;
-	obs_sceneitem_get_crop(sceneItem, &crop);
-	obs_data_set_int(cropData, "left", crop.left);
-	obs_data_set_int(cropData, "top", crop.top);
-	obs_data_set_int(cropData, "right", crop.right);
-	obs_data_set_int(cropData, "bottom", crop.bottom);
-	obs_data_set_obj(data, "crop", cropData);
-
-	obs_data_set_bool(data, "visible", obs_sceneitem_visible(sceneItem));
-
-	OBSDataAutoRelease boundsData = obs_data_create();
-	obs_bounds_type boundsType = obs_sceneitem_get_bounds_type(sceneItem);
-	if (boundsType == OBS_BOUNDS_NONE) {
-		obs_data_set_string(boundsData, "type", "OBS_BOUNDS_NONE");
-	}
-	else {
-		switch (boundsType) {
-		case OBS_BOUNDS_STRETCH: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_STRETCH");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_INNER: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_INNER");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_OUTER: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_OUTER");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_TO_WIDTH: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_WIDTH");
-			break;
-		}
-		case OBS_BOUNDS_SCALE_TO_HEIGHT: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_SCALE_TO_HEIGHT");
-			break;
-		}
-		case OBS_BOUNDS_MAX_ONLY: {
-			obs_data_set_string(boundsData, "type", "OBS_BOUNDS_MAX_ONLY");
-			break;
-		}
-		}
-		obs_data_set_int(boundsData, "alignment", obs_sceneitem_get_bounds_alignment(sceneItem));
-		vec2 bounds;
-		obs_sceneitem_get_bounds(sceneItem, &bounds);
-		obs_data_set_double(boundsData, "x", bounds.x);
-		obs_data_set_double(boundsData, "y", bounds.y);
-	}
-	obs_data_set_obj(data, "bounds", boundsData);
 
 	return req->SendOKResponse(data);
 }


### PR DESCRIPTION
##### Issue type
Feature request

##### Description
Current when a source on a scene is resized or moved there is no event to notify socket subscribers that this occured. OBS does emit `item_transform` for this.

Clone OnSceneItemAdd to a new function to support the `item_transform` signal. Emit as `SourceItemChanged`

Basically here I've just duplicated and adjusted `OnSceneItemAdd` to match the existing format.

Personally I'd extend to emit the details about the scene. But this doesn't match what the other events do in OBS-Websocket in this group.