### PR TITLE
Add caption handler

### DIFF
--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -34,6 +34,7 @@ git checkout $OBSLatestTag
 mkdir build && cd build
 echo "[obs-websocket] Building obs-studio.."
 cmake .. \
+	-DBUILD_CAPTIONS=true \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
 	-DDISABLE_PLUGINS=true \
 	-DDepsPath=/tmp/obsdeps \

--- a/CI/install-build-obs.cmd
+++ b/CI/install-build-obs.cmd
@@ -108,12 +108,12 @@ if defined BuildOBS (
 	mkdir build64
 	echo   Running cmake for obs-studio %OBSLatestTag% 32-bit...
 	cd ./build32
-	cmake -G "Visual Studio 14 2015" -DDISABLE_PLUGINS=true -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
+	cmake -G "Visual Studio 14 2015" -DBUILD_CAPTIONS=true -DDISABLE_PLUGINS=true -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
 	echo:
 	echo:
 	echo   Running cmake for obs-studio %OBSLatestTag% 64-bit...
 	cd ../build64
-	cmake -G "Visual Studio 14 2015 Win64" -DDISABLE_PLUGINS=true -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
+	cmake -G "Visual Studio 14 2015 Win64" -DBUILD_CAPTIONS=true -DDISABLE_PLUGINS=true -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true ..
 	echo:
 	echo:
 	echo   Building obs-studio %OBSLatestTag% 32-bit ^(Build Config: %build_config%^)...

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -103,7 +103,9 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "SetStreamSettings", WSRequestHandler::HandleSetStreamSettings },
 	{ "GetStreamSettings", WSRequestHandler::HandleGetStreamSettings },
 	{ "SaveStreamSettings", WSRequestHandler::HandleSaveStreamSettings },
+#if BUILD_CAPTIONS
 	{ "SendCaptions", WSRequestHandler::HandleSendCaptions },
+#endif
 
 	{ "GetStudioModeStatus", WSRequestHandler::HandleGetStudioModeStatus },
 	{ "GetPreviewScene", WSRequestHandler::HandleGetPreviewScene },

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -103,6 +103,7 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "SetStreamSettings", WSRequestHandler::HandleSetStreamSettings },
 	{ "GetStreamSettings", WSRequestHandler::HandleGetStreamSettings },
 	{ "SaveStreamSettings", WSRequestHandler::HandleSaveStreamSettings },
+	{ "SendCaptions", WSRequestHandler::HandleSendCaptions },
 
 	{ "GetStudioModeStatus", WSRequestHandler::HandleGetStudioModeStatus },
 	{ "GetPreviewScene", WSRequestHandler::HandleGetPreviewScene },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -128,6 +128,7 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleSetStreamSettings(WSRequestHandler* req);
 		static HandlerResponse HandleGetStreamSettings(WSRequestHandler* req);
 		static HandlerResponse HandleSaveStreamSettings(WSRequestHandler* req);
+		static HandlerResponse HandleSendCaptions(WSRequestHandler * req);
 
 		static HandlerResponse HandleSetTransitionDuration(WSRequestHandler* req);
 		static HandlerResponse HandleGetTransitionDuration(WSRequestHandler* req);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -128,7 +128,9 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleSetStreamSettings(WSRequestHandler* req);
 		static HandlerResponse HandleGetStreamSettings(WSRequestHandler* req);
 		static HandlerResponse HandleSaveStreamSettings(WSRequestHandler* req);
+#if BUILD_CAPTIONS
 		static HandlerResponse HandleSendCaptions(WSRequestHandler * req);
+#endif
 
 		static HandlerResponse HandleSetTransitionDuration(WSRequestHandler* req);
 		static HandlerResponse HandleGetTransitionDuration(WSRequestHandler* req);

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -8,7 +8,7 @@
 
  /**
  * Get current streaming and recording status.
- * 
+ *
  * @return {boolean} `streaming` Current streaming status.
  * @return {boolean} `recording` Current recording status.
  * @return {String (optional)} `stream-timecode` Time elapsed since streaming started (only present if currently streaming).
@@ -22,7 +22,7 @@
  */
 HandlerResponse WSRequestHandler::HandleGetStreamingStatus(WSRequestHandler* req) {
 	auto events = WSEvents::Current();
-	 
+
 	OBSDataAutoRelease data = obs_data_create();
 	obs_data_set_bool(data, "streaming", obs_frontend_streaming_active());
 	obs_data_set_bool(data, "recording", obs_frontend_recording_active());
@@ -65,7 +65,7 @@ HandlerResponse WSRequestHandler::HandleStartStopStreaming(WSRequestHandler* req
  *
  * @param {Object (optional)} `stream` Special stream configuration. Please note: these won't be saved to OBS' configuration.
  * @param {String (optional)} `stream.type` If specified ensures the type of stream matches the given type (usually 'rtmp_custom' or 'rtmp_common'). If the currently configured stream type does not match the given stream type, all settings must be specified in the `settings` object or an error will occur when starting the stream.
- * @param {Object (optional)} `stream.metadata` Adds the given object parameters as encoded query string parameters to the 'key' of the RTMP stream. Used to pass data to the RTMP service about the streaming. May be any String, Numeric, or Boolean field. 
+ * @param {Object (optional)} `stream.metadata` Adds the given object parameters as encoded query string parameters to the 'key' of the RTMP stream. Used to pass data to the RTMP service about the streaming. May be any String, Numeric, or Boolean field.
  * @param {Object (optional)} `stream.settings` Settings for the stream.
  * @param {String (optional)} `stream.settings.server` The publish URL.
  * @param {String (optional)} `stream.settings.key` The publish key of the stream.
@@ -185,7 +185,7 @@ HandlerResponse WSRequestHandler::HandleStopStreaming(WSRequestHandler* req) {
 
 /**
  * Sets one or more attributes of the current streaming server settings. Any options not passed will remain unchanged. Returns the updated settings in response. If 'type' is different than the current streaming service type, all settings are required. Returns the full settings of the stream (the same as GetStreamSettings).
- * 
+ *
  * @param {String} `type` The type of streaming service configuration, usually `rtmp_custom` or `rtmp_common`.
  * @param {Object} `settings` The actual settings of the stream.
  * @param {String (optional)} `settings.server` The publish URL.
@@ -290,7 +290,8 @@ HandlerResponse WSRequestHandler::HandleSaveStreamSettings(WSRequestHandler* req
 
 
 /**
- * Send the provided text as embedded CEA-608 caption data
+ * Send the provided text as embedded CEA-608 caption data.
+ * As of OBS Studio 23.1, captions are not yet available on Linux.
  *
  * @param {String} `text` Captions text
  *
@@ -298,6 +299,7 @@ HandlerResponse WSRequestHandler::HandleSaveStreamSettings(WSRequestHandler* req
  * @name SendCaptions
  * @category streaming
  */
+#if BUILD_CAPTIONS
 HandlerResponse WSRequestHandler::HandleSendCaptions(WSRequestHandler* req) {
 	if (!req->hasField("text")) {
 		return req->SendErrorResponse("missing request parameters");
@@ -311,4 +313,5 @@ HandlerResponse WSRequestHandler::HandleSendCaptions(WSRequestHandler* req) {
 
 	return req->SendOKResponse();
 }
+#endif
 

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -291,7 +291,9 @@ HandlerResponse WSRequestHandler::HandleSaveStreamSettings(WSRequestHandler* req
 
 /**
  * Send the provided text as embedded CEA-608 caption data
- * 
+ *
+ * @param {String} `text` Captions text
+ *
  * @api requests
  * @name SendCaptions
  * @category streaming

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -287,3 +287,26 @@ HandlerResponse WSRequestHandler::HandleSaveStreamSettings(WSRequestHandler* req
 	obs_frontend_save_streaming_service();
 	return req->SendOKResponse();
 }
+
+
+/**
+ * Send the provided text as embedded CEA-608 caption data
+ * 
+ * @api requests
+ * @name SendCaptions
+ * @category streaming
+ */
+HandlerResponse WSRequestHandler::HandleSendCaptions(WSRequestHandler* req) {
+	if (!req->hasField("text")) {
+		return req->SendErrorResponse("missing request parameters");
+	}
+
+	OBSOutputAutoRelease output = obs_frontend_get_streaming_output();
+	if (output) {
+		const char* caption = obs_data_get_string(req->data, "text");
+		obs_output_output_caption_text1(output, caption);
+	}
+
+	return req->SendOKResponse();
+}
+


### PR DESCRIPTION
Added a handler that allows sending text as captions through OBS' built-in caption functionality.

I wasn't sure where to add it, so I just put it into streaming.

Also I hacked together a little demo site: https://rodney.io/stuff/obscaptions/ Just click the mic and it will (try to) connect to OBS and start sending captions. It would need a lot more work to be useful, but it works.