### PR TITLE
docs(jsdoc): clean up types for compatability with obs-websocket-js typedef generator

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -3107,7 +3107,7 @@
         "description": "Changes the order of scene items in the requested scene.",
         "param": [
           "{String (optional)} `scene` Name of the scene to reorder (defaults to current).",
-          "{Scene|Array} `items` Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene",
+          "{Array<Scene>} `items` Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene",
           "{int (optional)} `items[].id` Id of a specific scene item. Unique on a scene by scene basis.",
           "{String (optional)} `items[].name` Name of a scene item. Sufficiently unique if no scene items share sources within the scene."
         ],
@@ -3122,7 +3122,7 @@
             "description": "Name of the scene to reorder (defaults to current)."
           },
           {
-            "type": "Scene|Array",
+            "type": "Array<Scene>",
             "name": "items",
             "description": "Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene"
           },

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -1477,7 +1477,7 @@ Changes the order of scene items in the requested scene.
 | Name | Type  | Description |
 | ---- | :---: | ------------|
 | `scene` | _String (optional)_ | Name of the scene to reorder (defaults to current). |
-| `items` | _Scene\|Array_ | Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene |
+| `items` | _Array&lt;Scene&gt;_ | Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene |
 | `items[].id` | _int (optional)_ | Id of a specific scene item. Unique on a scene by scene basis. |
 | `items[].name` | _String (optional)_ | Name of a scene item. Sufficiently unique if no scene items share sources within the scene. |
 

--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -84,7 +84,7 @@ HandlerResponse WSRequestHandler::HandleGetSceneList(WSRequestHandler* req) {
 * Changes the order of scene items in the requested scene.
 *
 * @param {String (optional)} `scene` Name of the scene to reorder (defaults to current).
-* @param {Scene|Array} `items` Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene
+* @param {Array<Scene>} `items` Ordered list of objects with name and/or id specified. Id preferred due to uniqueness per scene
 * @param {int (optional)} `items[].id` Id of a specific scene item. Unique on a scene by scene basis.
 * @param {String (optional)} `items[].name` Name of a scene item. Sufficiently unique if no scene items share sources within the scene.
 *


### PR DESCRIPTION
This small change is all that is needed to get the [typedef generator for obs-websocket-js](https://github.com/haganbmj/obs-websocket-js/pull/126) working again. Unfortunately, I think we need to cut a new release of `obs-websocket` once this gets merged, as the build process for `obs-websocket-js` is currently built to look at whatever the latest release tag is here on GitHub for `obs-websocket`, and I'd like to avoid making it look at a specific commit or something similar.