### PR TITLE
events refactor (transitions & scene signals) + new events

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -19,8 +19,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-frontend-api.h>
 #include <util/config-file.h>
 
-#include <QCryptographicHash>
-#include <QTime>
+#include <QtCore/QCryptographicHash>
+#include <QtCore/QTime>
 
 #define SECTION_NAME "WebsocketAPI"
 #define PARAM_ENABLE "ServerEnabled"

--- a/src/Config.h
+++ b/src/Config.h
@@ -18,8 +18,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
-#include <QString>
-#include <QSharedPointer>
+#include <QtCore/QString>
+#include <QtCore/QSharedPointer>
 
 class Config;
 typedef QSharedPointer<Config> ConfigPtr;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -48,22 +48,28 @@ obs_bounds_type getBoundsTypeFromName(QString name) {
 	return boundTypeNames.key(name);
 }
 
-obs_data_array_t* Utils::StringListToArray(char** strings, char* key) {
-	if (!strings)
-		return obs_data_array_create();
-
+obs_data_array_t* Utils::StringListToArray(char** strings, const char* key) {
 	obs_data_array_t* list = obs_data_array_create();
 
-	char* value = "";
-	for (int i = 0; value != nullptr; i++) {
-		value = strings[i];
+	if (!strings || !key) {
+		return list; // empty list
+	}
+
+	size_t index = 0;
+	char* value = nullptr;
+
+	do {
+		value = strings[index];
 
 		OBSDataAutoRelease item = obs_data_create();
 		obs_data_set_string(item, key, value);
 
-		if (value)
+		if (value) {
 			obs_data_array_push_back(list, item);
-	}
+		}
+
+		index++;
+	} while (value != nullptr);
 
 	return list;
 }
@@ -72,8 +78,9 @@ obs_data_array_t* Utils::GetSceneItems(obs_source_t* source) {
 	obs_data_array_t* items = obs_data_array_create();
 	OBSScene scene = obs_scene_from_source(source);
 
-	if (!scene)
+	if (!scene) {
 		return nullptr;
+	}
 
 	obs_scene_enum_items(scene, [](
 			obs_scene_t* scene,
@@ -91,8 +98,9 @@ obs_data_array_t* Utils::GetSceneItems(obs_source_t* source) {
 }
 
 obs_data_t* Utils::GetSceneItemData(obs_sceneitem_t* item) {
-	if (!item)
+	if (!item) {
 		return nullptr;
+	}
 
 	vec2 pos;
 	obs_sceneitem_get_pos(item, &pos);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -16,9 +16,10 @@ You should have received a copy of the GNU General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
-#include <QMainWindow>
-#include <QDir>
-#include <QUrl>
+#include <QtWidgets/QMainWindow>
+#include <QtCore/QDir>
+#include <QtCore/QUrl>
+
 #include <obs-frontend-api.h>
 #include <obs.hpp>
 #include "obs-websocket.h"

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -20,11 +20,12 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <stdio.h>
 
-#include <QSpinBox>
-#include <QPushButton>
-#include <QLayout>
-#include <QListWidget>
-#include <QSystemTrayIcon>
+#include <QtCore/QString>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QLayout>
+#include <QtWidgets/QListWidget>
+#include <QtWidgets/QSystemTrayIcon>
 
 #include <obs.hpp>
 #include <obs-module.h>

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -51,6 +51,7 @@ class Utils {
 	static obs_data_array_t* GetScenes();
 	static obs_data_t* GetSceneData(obs_source_t* source);
 
+	// TODO contribute a proper frontend API method for this to OBS and remove this hack
 	static QSpinBox* GetTransitionDurationControl();
 	static int GetTransitionDuration();
 	static void SetTransitionDuration(int ms);
@@ -60,8 +61,10 @@ class Utils {
 	static QPushButton* GetPreviewModeButtonControl();
 	static QLayout* GetPreviewLayout();
 	static QListWidget* GetSceneListControl();
+	// TODO remove this hack
 	static obs_scene_t* SceneListItemToScene(QListWidgetItem* item);
 
+	// TODO contribute a proper frontend API method for this to OBS and remove this hack
 	static void TransitionToProgram();
 
 	static QString OBSVersionString();

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -43,6 +43,8 @@ class Utils {
 	static obs_source_t* GetTransitionFromName(QString transitionName);
 	static obs_source_t* GetSceneFromNameOrCurrent(QString sceneName);
 	static obs_data_t* GetSceneItemPropertiesData(obs_sceneitem_t* item);
+	
+	static obs_data_array_t* GetSourceFiltersList(obs_source_t* source, bool includeSettings);
 
 	static bool IsValidAlignment(const uint32_t alignment);
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -33,7 +33,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 class Utils {
   public:
-	static obs_data_array_t* StringListToArray(char** strings, char* key);
+	static obs_data_array_t* StringListToArray(char** strings, const char* key);
 	static obs_data_array_t* GetSceneItems(obs_source_t* source);
 	static obs_data_t* GetSceneItemData(obs_sceneitem_t* item);
 	static obs_sceneitem_t* GetSceneItemFromName(

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -770,6 +770,18 @@ void WSEvents::OnSourceCreate(void* param, calldata_t* data) {
 	obs_source_type sourceType = obs_source_get_type(source);
 	signal_handler_t* sh = obs_source_get_signal_handler(source);
 
+	// TODO "mute" signal
+	// TODO "volume" signal
+	// TODO "audio_sync" signal
+	// TODO "audio_mixers" signal
+
+	// TODO "rename" signal
+	// TODO "update_properties"
+
+	// TODO "filter_add" signal
+	// TODO "filter_remove" signal
+	// TODO "reorder_filters" signal
+
 	if (sourceType == OBS_SOURCE_TYPE_SCENE) {
 		signal_handler_connect(sh, "reorder", OnSceneReordered, self);
 		signal_handler_connect(sh, "item_add", OnSceneItemAdd, self);

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -903,7 +903,7 @@ void WSEvents::OnSourceMuteStateChange(void* param, calldata_t* data) {
  * The audio sync offset of a source has changed.
  *
  * @return {String} `sourceName` Source name
- * @return {int} `syncOffset` Audio sync offset of the source
+ * @return {int} `syncOffset` Audio sync offset of the source (in nanoseconds)
  *
  * @api events
  * @name SourceAudioSyncOffsetChanged

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -1058,7 +1058,7 @@ void WSEvents::OnSourceFilterAdded(void* param, calldata_t* data) {
 void WSEvents::OnSourceFilterRemoved(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
-	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	obs_source_t* source = calldata_get_pointer<obs_source_t>(data, "source");
 	if (!source) {
 		return;
 	}

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -19,7 +19,7 @@
 
 #include <util/platform.h>
 
-#include <QPushButton>
+#include <QtWidgets/QPushButton>
 
 #include "Config.h"
 #include "Utils.h"

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -836,6 +836,17 @@ void WSEvents::OnSourceDestroy(void* param, calldata_t* data) {
 	self->broadcastUpdate("SourceDestroyed", fields);
 }
 
+/**
+ * The volume of a source has changed.
+ *
+ * @return {String} `sourceName` Source name
+ * @return {float} `volume` Source volume
+ *
+ * @api events
+ * @name SourceVolumeChanged
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceVolumeChange(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -844,14 +855,28 @@ void WSEvents::OnSourceVolumeChange(void* param, calldata_t* data) {
 		return;
 	}
 
-	double volume;
+	double volume = 0;
 	if (!calldata_get_float(data, "volume", &volume)) {
 		return;
 	}
 
-	// TODO
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	obs_data_set_double(fields, "volume", volume);
+	self->broadcastUpdate("SourceVolumeChanged", fields);
 }
 
+/**
+ * A source has been muted or unmuted.
+ *
+ * @return {String} `sourceName` Source name
+ * @return {boolean} `mute` Mute status of the source
+ *
+ * @api events
+ * @name SourceMuteStateChanged
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceMuteStateChange(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -860,12 +885,28 @@ void WSEvents::OnSourceMuteStateChange(void* param, calldata_t* data) {
 		return;
 	}
 
-	bool mute;
+	bool mute = false;
 	if (!calldata_get_bool(data, "mute", &mute)) {
 		return;
 	}
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	obs_data_set_bool(fields, "mute", mute);
+	self->broadcastUpdate("SourceMuteStateChanged", fields);
 }
 
+/**
+ * The audio sync offset of a source has changed.
+ *
+ * @return {String} `sourceName` Source name
+ * @return {int} `syncOffset` Audio sync offset of the source
+ *
+ * @api events
+ * @name SourceAudioSyncOffsetChanged
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -879,9 +920,22 @@ void WSEvents::OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data) {
 		return;
 	}
 
-	// TODO
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	obs_data_set_int(fields, "syncOffset", (int)syncOffset);
+	self->broadcastUpdate("SourceAudioSyncOffsetChanged", fields);
 }
 
+/**
+ * CHANGEME.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name CHANGEME
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceAudioMixersChanged(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -898,6 +952,19 @@ void WSEvents::OnSourceAudioMixersChanged(void* param, calldata_t* data) {
 	// TODO
 }
 
+/**
+ * A source has been renamed.
+ *
+ * @return {String} `previousName` Previous source name
+ * @return {String} `newName` New source name
+ * 
+ * TODO which one is current?
+ * 
+ * @api events
+ * @name SourceRenamed
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceRename(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -914,9 +981,22 @@ void WSEvents::OnSourceRename(void* param, calldata_t* data) {
 	const char* previousName = calldata_get_string(data, "prev_name");
 	// TODO check?
 
-	// TODO
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "previousName", previousName);
+	obs_data_set_string(fields, "newName", newName);
+	self->broadcastUpdate("SourceRenamed", fields);
 }
 
+/**
+ * The properties of a source have changed.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name SourcePropertiesChanged
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourcePropertiesChanged(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -925,9 +1005,22 @@ void WSEvents::OnSourcePropertiesChanged(void* param, calldata_t* data) {
 		return;
 	}
 
-	// TODO
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	// TODO provide properties?
+	self->broadcastUpdate("SourcePropertiesChanged", fields);
 }
 
+/**
+ * A filter was added to a source.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name SourceFilterAdded
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceFilterAdded(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -941,9 +1034,25 @@ void WSEvents::OnSourceFilterAdded(void* param, calldata_t* data) {
 		return;
 	}
 
-	// TODO
+	OBSDataAutoRelease filterSettings = obs_source_get_settings(filter);
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	obs_data_set_string(fields, "filterName", obs_source_get_name(filter));
+	obs_data_set_obj(fields, "filterSettings", filterSettings);
+	self->broadcastUpdate("SourceFilterAdded", fields);
 }
 
+/**
+ * A filter was removed from a source.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name SourceFilterRemoved
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceFilterRemoved(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -954,9 +1063,22 @@ void WSEvents::OnSourceFilterRemoved(void* param, calldata_t* data) {
 
 	obs_source_t* filter = calldata_get_pointer<obs_source_t>(data, "filter");
 
-	// TODO
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	obs_data_set_string(fields, "filterName", obs_source_get_name(filter));
+	self->broadcastUpdate("SourceFilterRemoved", fields);
 }
 
+/**
+ * Filters in a source have been reordered.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name SourceFiltersReordered
+ * @category sources
+ * @since 4.6.0
+ */
 void WSEvents::OnSourceFilterOrderChanged(void* param, calldata_t* data) {
 	auto self = reinterpret_cast<WSEvents*>(param);
 
@@ -965,7 +1087,10 @@ void WSEvents::OnSourceFilterOrderChanged(void* param, calldata_t* data) {
 		return;
 	}
 
-	// TODO
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	// TODO filters list
+	self->broadcastUpdate("SourceFiltersReordered", fields);
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -95,8 +95,6 @@ void WSEvents::ResetCurrent(WSServerPtr srv) {
 
 WSEvents::WSEvents(WSServerPtr srv) :
 	_srv(srv),
-	_streamingActive(false),
-	_recordingActive(false),
 	_streamStarttime(0),
 	_recStarttime(0),
 	HeartbeatIsActive(false),

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -130,7 +130,7 @@ WSEvents::~WSEvents() {
 }
 
 void WSEvents::FrontendEventHandler(enum obs_frontend_event event, void* private_data) {
-	WSEvents* owner = static_cast<WSEvents*>(private_data);
+	auto owner = reinterpret_cast<WSEvents*>(private_data);
 
 	if (!owner->_srv) {
 		return;

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -29,12 +29,6 @@
 
 #define STATUS_INTERVAL 2000
 
-/**
-* @typedef {Object} `SourceRoutingStatus`
-* @property {int} `id` Mixer number
-* @property {boolean} `enabled` Routing status
-*/
-
 bool transitionIsCut(obs_source_t* transition) {
 	if (!transition)
 		return false;
@@ -937,7 +931,9 @@ void WSEvents::OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data) {
  * Audio mixer routing changed on a source.
  *
  * @return {String} `sourceName` Source name
- * @return {Array<SourceRoutingStatus>} `routingStatus` Routing status of the source for each audio mixer (array of 6 values)
+ * @return {Array<Object>} `routingStatus` Routing status of the source for each audio mixer (array of 6 values)
+ * @return {int} `routingStatus.*.id` Mixer number
+ * @return {boolean} `routingStatus.*.enabled` Routing status
  * @return {String} `hexMixersValue` Raw mixer flags (little-endian, one bit per mixer) as an hexadecimal value 
  *
  * @api events

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -762,6 +762,7 @@ void WSEvents::OnTransitionBegin(void* param, calldata_t* data) {
  *
  * @return {String} `sourceName` Source name
  * @return {String} `sourceType` Source type. Can be "input", "scene", "transition" or "filter".
+ * @return {String} `sourceKind` Source kind.
  * @return {Object} `sourceSettings` Source settings
  *
  * @api events
@@ -808,6 +809,7 @@ void WSEvents::OnSourceCreate(void* param, calldata_t* data) {
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(fields, "sourceType", sourceTypeToString(sourceType));
+	obs_data_set_string(fields, "sourceKind", obs_source_get_id(source));
 	obs_data_set_obj(fields, "sourceSettings", sourceSettings);
 	self->broadcastUpdate("SourceCreated", fields);
 }
@@ -817,6 +819,7 @@ void WSEvents::OnSourceCreate(void* param, calldata_t* data) {
  *
  * @return {String} `sourceName` Source name
  * @return {String} `sourceType` Source type. Can be "input", "scene", "transition" or "filter".
+ * @return {String} `sourceKind` Source kind.
  *
  * @api events
  * @name SourceDestroyed
@@ -836,6 +839,7 @@ void WSEvents::OnSourceDestroy(void* param, calldata_t* data) {
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(fields, "sourceType", sourceTypeToString(sourceType));
+	obs_data_set_string(fields, "sourceKind", obs_source_get_id(source));
 	self->broadcastUpdate("SourceDestroyed", fields);
 }
 
@@ -934,7 +938,7 @@ void WSEvents::OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data) {
  *
  * @return {String} `sourceName` Source name
  * @return {Array<SourceRoutingStatus>} `routingStatus` Routing status of the source for each audio mixer (array of 6 values)
- * @return {String} `hexMixersValue` Mixers 
+ * @return {String} `hexMixersValue` Raw mixer flags (little-endian, one bit per mixer) as an hexadecimal value 
  *
  * @api events
  * @name OnSourceAudioMixersChanged
@@ -955,7 +959,7 @@ void WSEvents::OnSourceAudioMixersChanged(void* param, calldata_t* data) {
 	}
 
 	OBSDataArrayAutoRelease mixers = obs_data_array_create();
-	for (size_t i = 0; i < 6; i++) {
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
 		OBSDataAutoRelease item = obs_data_create();
 		obs_data_set_int(item, "id", i + 1);
 		obs_data_set_bool(item, "enabled", (1 << i) & audioMixers);
@@ -976,8 +980,6 @@ void WSEvents::OnSourceAudioMixersChanged(void* param, calldata_t* data) {
  *
  * @return {String} `previousName` Previous source name
  * @return {String} `newName` New source name
- * 
- * TODO which one is current?
  * 
  * @api events
  * @name SourceRenamed

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -777,7 +777,6 @@ void WSEvents::OnSourceCreate(void* param, calldata_t* data) {
 	signal_handler_t* sh = obs_source_get_signal_handler(source);
 
 	signal_handler_connect(sh, "rename", OnSourceRename, self);
-	signal_handler_connect(sh, "update_properties", OnSourcePropertiesChanged, self);
 
 	signal_handler_connect(sh, "mute", OnSourceMuteStateChange, self);
 	signal_handler_connect(sh, "volume", OnSourceVolumeChange, self);
@@ -985,30 +984,6 @@ void WSEvents::OnSourceRename(void* param, calldata_t* data) {
 	obs_data_set_string(fields, "previousName", previousName);
 	obs_data_set_string(fields, "newName", newName);
 	self->broadcastUpdate("SourceRenamed", fields);
-}
-
-/**
- * The properties of a source have changed.
- *
- * @return {String} `sourceName` Source name
- *
- * @api events
- * @name SourcePropertiesChanged
- * @category sources
- * @since 4.6.0
- */
-void WSEvents::OnSourcePropertiesChanged(void* param, calldata_t* data) {
-	auto self = reinterpret_cast<WSEvents*>(param);
-
-	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
-	if (!source) {
-		return;
-	}
-
-	OBSDataAutoRelease fields = obs_data_create();
-	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
-	// TODO provide properties?
-	self->broadcastUpdate("SourcePropertiesChanged", fields);
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -873,7 +873,7 @@ void WSEvents::OnSourceVolumeChange(void* param, calldata_t* data) {
  * A source has been muted or unmuted.
  *
  * @return {String} `sourceName` Source name
- * @return {boolean} `mute` Mute status of the source
+ * @return {boolean} `muted` Mute status of the source
  *
  * @api events
  * @name SourceMuteStateChanged
@@ -888,14 +888,14 @@ void WSEvents::OnSourceMuteStateChange(void* param, calldata_t* data) {
 		return;
 	}
 
-	bool mute = false;
-	if (!calldata_get_bool(data, "mute", &mute)) {
+	bool muted = false;
+	if (!calldata_get_bool(data, "muted", &muted)) {
 		return;
 	}
 
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
-	obs_data_set_bool(fields, "mute", mute);
+	obs_data_set_bool(fields, "muted", muted);
 	self->broadcastUpdate("SourceMuteStateChanged", fields);
 }
 

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -51,8 +51,7 @@ const char* nsToTimestamp(uint64_t ns) {
 	uint64_t msPart = ms % 1000;
 
 	char* ts = (char*)bmalloc(64);
-	sprintf(ts, "%02d:%02d:%02d.%03d",
-		hoursPart, minutesPart, secsPart, msPart);
+	sprintf(ts, "%02lu:%02lu:%02lu.%03lu", hoursPart, minutesPart, secsPart, msPart);
 
 	return ts;
 }

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -998,7 +998,6 @@ void WSEvents::OnSourceRename(void* param, calldata_t* data) {
 	}
 
 	const char* previousName = calldata_get_string(data, "prev_name");
-	// TODO check?
 
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "previousName", previousName);
@@ -1010,6 +1009,9 @@ void WSEvents::OnSourceRename(void* param, calldata_t* data) {
  * A filter was added to a source.
  *
  * @return {String} `sourceName` Source name
+ * @return {String} `filterName` Filter name
+ * @return {String} `filterType` Filter type
+ * @return {Object} `filterSettings` Filter settings
  *
  * @api events
  * @name SourceFilterAdded
@@ -1034,6 +1036,7 @@ void WSEvents::OnSourceFilterAdded(void* param, calldata_t* data) {
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(fields, "filterName", obs_source_get_name(filter));
+	obs_data_set_string(fields, "filterType", obs_source_get_id(filter));
 	obs_data_set_obj(fields, "filterSettings", filterSettings);
 	self->broadcastUpdate("SourceFilterAdded", fields);
 }
@@ -1042,6 +1045,8 @@ void WSEvents::OnSourceFilterAdded(void* param, calldata_t* data) {
  * A filter was removed from a source.
  *
  * @return {String} `sourceName` Source name
+ * @return {String} `filterName` Filter name
+ * @return {String} `filterType` Filter type
  *
  * @api events
  * @name SourceFilterRemoved
@@ -1061,6 +1066,7 @@ void WSEvents::OnSourceFilterRemoved(void* param, calldata_t* data) {
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(fields, "filterName", obs_source_get_name(filter));
+	obs_data_set_string(fields, "filterType", obs_source_get_id(filter));
 	self->broadcastUpdate("SourceFilterRemoved", fields);
 }
 
@@ -1068,6 +1074,9 @@ void WSEvents::OnSourceFilterRemoved(void* param, calldata_t* data) {
  * Filters in a source have been reordered.
  *
  * @return {String} `sourceName` Source name
+ * @return {Array<Object>} `filters` Ordered Filters list
+ * @return {String} `filters.*.name` Filter name
+ * @return {String} `filters.*.type` Filter type
  *
  * @api events
  * @name SourceFiltersReordered
@@ -1082,9 +1091,11 @@ void WSEvents::OnSourceFilterOrderChanged(void* param, calldata_t* data) {
 		return;
 	}
 
+	OBSDataArrayAutoRelease filters = Utils::GetSourceFiltersList(source, false);
+
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
-	// TODO filters list
+	obs_data_set_array(fields, "filters", filters);
 	self->broadcastUpdate("SourceFiltersReordered", fields);
 }
 

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -77,6 +77,12 @@ template <typename T> T* calldata_get_pointer(const calldata_t* data, const char
 	return reinterpret_cast<T*>(ptr);
 }
 
+const char* calldata_get_string(const calldata_t* data, const char* name) {
+	const char* value = nullptr;
+	calldata_get_string(data, name, &value);
+	return value;
+}
+
 WSEventsPtr WSEvents::_instance = WSEventsPtr(nullptr);
 
 WSEventsPtr WSEvents::Current() {
@@ -770,17 +776,17 @@ void WSEvents::OnSourceCreate(void* param, calldata_t* data) {
 	obs_source_type sourceType = obs_source_get_type(source);
 	signal_handler_t* sh = obs_source_get_signal_handler(source);
 
-	// TODO "mute" signal
-	// TODO "volume" signal
-	// TODO "audio_sync" signal
-	// TODO "audio_mixers" signal
+	signal_handler_connect(sh, "rename", OnSourceRename, self);
+	signal_handler_connect(sh, "update_properties", OnSourcePropertiesChanged, self);
 
-	// TODO "rename" signal
-	// TODO "update_properties"
+	signal_handler_connect(sh, "mute", OnSourceMuteStateChange, self);
+	signal_handler_connect(sh, "volume", OnSourceVolumeChange, self);
+	signal_handler_connect(sh, "audio_sync", OnSourceAudioSyncOffsetChanged, self);
+	signal_handler_connect(sh, "audio_mixers", OnSourceAudioMixersChanged, self);
 
-	// TODO "filter_add" signal
-	// TODO "filter_remove" signal
-	// TODO "reorder_filters" signal
+	signal_handler_connect(sh, "filter_add", OnSourceFilterAdded, self);
+	signal_handler_connect(sh, "filter_remove", OnSourceFilterRemoved, self);
+	signal_handler_connect(sh, "reorder_filters", OnSourceFilterOrderChanged, self);
 
 	if (sourceType == OBS_SOURCE_TYPE_SCENE) {
 		signal_handler_connect(sh, "reorder", OnSceneReordered, self);
@@ -828,6 +834,138 @@ void WSEvents::OnSourceDestroy(void* param, calldata_t* data) {
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(fields, "sourceType", sourceTypeToString(sourceType));
 	self->broadcastUpdate("SourceDestroyed", fields);
+}
+
+void WSEvents::OnSourceVolumeChange(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	double volume;
+	if (!calldata_get_float(data, "volume", &volume)) {
+		return;
+	}
+
+	// TODO
+}
+
+void WSEvents::OnSourceMuteStateChange(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	bool mute;
+	if (!calldata_get_bool(data, "mute", &mute)) {
+		return;
+	}
+}
+
+void WSEvents::OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	long long syncOffset;
+	if (!calldata_get_int(data, "offset", &syncOffset)) {
+		return;
+	}
+
+	// TODO
+}
+
+void WSEvents::OnSourceAudioMixersChanged(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	long long audioMixers;
+	if (!calldata_get_int(data, "mixers", &audioMixers)) {
+		return;
+	}
+
+	// TODO
+}
+
+void WSEvents::OnSourceRename(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	const char* newName = calldata_get_string(data, "new_name");
+	if (!newName) {
+		return;
+	}
+
+	const char* previousName = calldata_get_string(data, "prev_name");
+	// TODO check?
+
+	// TODO
+}
+
+void WSEvents::OnSourcePropertiesChanged(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	// TODO
+}
+
+void WSEvents::OnSourceFilterAdded(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	OBSSource filter = calldata_get_pointer<obs_source_t>(data, "filter");
+	if (!filter) {
+		return;
+	}
+
+	// TODO
+}
+
+void WSEvents::OnSourceFilterRemoved(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	obs_source_t* filter = calldata_get_pointer<obs_source_t>(data, "filter");
+
+	// TODO
+}
+
+void WSEvents::OnSourceFilterOrderChanged(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	// TODO
 }
 
 /**

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -22,8 +22,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
 
-#include <QListWidgetItem>
-#include <QSharedPointer>
+#include <QtWidgets/QListWidgetItem>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QTimer>
 
 #include "WSServer.h"

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -117,7 +117,6 @@ private:
 	static void OnSourceAudioMixersChanged(void* param, calldata_t* data);
 
 	static void OnSourceRename(void* param, calldata_t* data);
-	static void OnSourcePropertiesChanged(void* param, calldata_t* data);
 
 	static void OnSourceFilterAdded(void* param, calldata_t* data);
 	static void OnSourceFilterRemoved(void* param, calldata_t* data);

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -44,8 +44,6 @@ public:
 	static void FrontendEventHandler(
 		enum obs_frontend_event event, void* privateData);
 
-	void hookTransitionBeginEvent();
-
 	uint64_t GetStreamingTime();
 	const char* GetStreamingTimecode();
 	uint64_t GetRecordingTime();

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -109,6 +109,7 @@ private:
 	static void OnTransitionBegin(void* param, calldata_t* data);
 
 	static void OnSourceCreate(void* param, calldata_t* data);
+	static void OnSourceDestroy(void* param, calldata_t* data);
 
 	static void OnSceneReordered(void* param, calldata_t* data);
 	static void OnSceneItemAdd(void* param, calldata_t* data);

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -43,7 +43,6 @@ public:
 	~WSEvents();
 	static void FrontendEventHandler(
 		enum obs_frontend_event event, void* privateData);
-	void connectSceneSignals(obs_source_t* scene);
 
 	void hookTransitionBeginEvent();
 
@@ -55,7 +54,6 @@ public:
 	bool HeartbeatIsActive;
 
 private slots:
-	void deferredInitOperations();
 	void StreamStatus();
 	void Heartbeat();
 	void TransitionDurationChanged(int ms);
@@ -111,6 +109,8 @@ private:
 	void OnExit();
 
 	static void OnTransitionBegin(void* param, calldata_t* data);
+
+	static void OnSourceCreate(void* param, calldata_t* data);
 
 	static void OnSceneReordered(void* param, calldata_t* data);
 	static void OnSceneItemAdd(void* param, calldata_t* data);

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -111,6 +111,18 @@ private:
 	static void OnSourceCreate(void* param, calldata_t* data);
 	static void OnSourceDestroy(void* param, calldata_t* data);
 
+	static void OnSourceVolumeChange(void* param, calldata_t* data);
+	static void OnSourceMuteStateChange(void* param, calldata_t* data);
+	static void OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data);
+	static void OnSourceAudioMixersChanged(void* param, calldata_t* data);
+
+	static void OnSourceRename(void* param, calldata_t* data);
+	static void OnSourcePropertiesChanged(void* param, calldata_t* data);
+
+	static void OnSourceFilterAdded(void* param, calldata_t* data);
+	static void OnSourceFilterRemoved(void* param, calldata_t* data);
+	static void OnSourceFilterOrderChanged(void* param, calldata_t* data);
+
 	static void OnSceneReordered(void* param, calldata_t* data);
 	static void OnSceneItemAdd(void* param, calldata_t* data);
 	static void OnSceneItemDelete(void* param, calldata_t* data);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -19,9 +19,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
-#include <QHash>
-#include <QSet>
-#include <QVariantHash>
+#include <QtCore/QHash>
+#include <QtCore/QSet>
+#include <QtCore/QVariantHash>
+#include <QtCore/QString>
 
 #include <obs.hpp>
 #include <obs-frontend-api.h>

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -1,5 +1,3 @@
-#include <QString>
-
 #include "Config.h"
 #include "Utils.h"
 #include "WSEvents.h"

--- a/src/WSRequestHandler_Profiles.cpp
+++ b/src/WSRequestHandler_Profiles.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_Recording.cpp
+++ b/src/WSRequestHandler_Recording.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_ReplayBuffer.cpp
+++ b/src/WSRequestHandler_ReplayBuffer.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_SceneCollections.cpp
+++ b/src/WSRequestHandler_SceneCollections.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1090,16 +1090,7 @@ HandlerResponse WSRequestHandler::HandleGetSourceFilters(WSRequestHandler* req)
 		return req->SendErrorResponse("specified source doesn't exist");
 	}
 
-	OBSDataArrayAutoRelease filters = obs_data_array_create();
-	obs_source_enum_filters(source, [](obs_source_t *parent, obs_source_t *child, void *param)
-	{
-		OBSDataAutoRelease filter = obs_data_create();
-		obs_data_set_string(filter, "type", obs_source_get_id(child));
-		obs_data_set_string(filter, "name", obs_source_get_name(child));
-		obs_data_set_obj(filter, "settings", obs_source_get_settings(child));
-		obs_data_array_push_back((obs_data_array_t*)param, filter);
-
-	}, filters);
+	OBSDataArrayAutoRelease filters = Utils::GetSourceFiltersList(source, true);
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_array(response, "filters", filters);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 #include "WSEvents.h"
 

--- a/src/WSRequestHandler_StudioMode.cpp
+++ b/src/WSRequestHandler_StudioMode.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_Transitions.cpp
+++ b/src/WSRequestHandler_Transitions.cpp
@@ -1,4 +1,3 @@
-#include <QString>
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSServer.cpp
+++ b/src/WSServer.cpp
@@ -18,8 +18,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <QtCore/QThread>
 #include <QtCore/QByteArray>
-#include <QMainWindow>
-#include <QMessageBox>
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QMessageBox>
 #include <QtConcurrent/QtConcurrent>
 #include <obs-frontend-api.h>
 

--- a/src/WSServer.h
+++ b/src/WSServer.h
@@ -18,10 +18,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
-#include <QObject>
-#include <QMutex>
-#include <QSharedPointer>
-#include <QVariantHash>
+#include <QtCore/QObject>
+#include <QtCore/QMutex>
+#include <QtCore/QSharedPointer>
+#include <QtCore/QVariantHash>
 
 #include <map>
 #include <set>

--- a/src/forms/settings-dialog.h
+++ b/src/forms/settings-dialog.h
@@ -18,7 +18,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
-#include <QDialog>
+#include <QtWidgets/QDialog>
 
 #include "ui_settings-dialog.h"
 

--- a/src/obs-websocket.cpp
+++ b/src/obs-websocket.cpp
@@ -18,9 +18,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <obs-module.h>
 #include <obs-frontend-api.h>
-#include <QAction>
-#include <QMainWindow>
-#include <QTimer>
+
+#include <QtCore/QTimer>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QMainWindow>
 
 #include "obs-websocket.h"
 #include "WSServer.h"


### PR DESCRIPTION
To do:
- [X] Scene events working in Studio Mode Preview
- [X] Fix how the plugin listens for transition begin signals
- [X] New source events: SourceCreated and SourceDestroyed
- [x] Audio mixing events
- [x] Source change events: rename, filters added/removed/reordered

Fixes #75, fixes  #48 