### PR TITLE
Fix call name GetSourcesTypesList -> GetSourceTypesList

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -3527,7 +3527,7 @@
           "{Boolean} `ids.*.caps.doNotSelfMonitor` True if sources of this type may cause a feedback loop if it's audio is monitored and shouldn't be"
         ],
         "api": "requests",
-        "name": "GetSourcesTypesList",
+        "name": "GetSourceTypesList",
         "category": "sources",
         "since": "4.3.0",
         "returns": [
@@ -3600,7 +3600,7 @@
         "names": [
           {
             "name": "",
-            "description": "GetSourcesTypesList"
+            "description": "GetSourceTypesList"
           }
         ],
         "categories": [
@@ -3617,7 +3617,7 @@
         ],
         "heading": {
           "level": 2,
-          "text": "GetSourcesTypesList"
+          "text": "GetSourceTypesList"
         },
         "lead": "",
         "type": "class",

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -133,7 +133,7 @@ auth_response = base64_encode(auth_response_hash)
     + [ReorderSceneItems](#reordersceneitems)
   * [Sources](#sources-1)
     + [GetSourcesList](#getsourceslist)
-    + [GetSourcesTypesList](#getsourcestypeslist)
+    + [GetSourceTypesList](#getsourcetypeslist)
     + [GetVolume](#getvolume)
     + [SetVolume](#setvolume)
     + [GetMute](#getmute)
@@ -1552,7 +1552,7 @@ _No specified parameters._
 
 ---
 
-### GetSourcesTypesList
+### GetSourceTypesList
 
 
 - Added in v4.3.0

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -94,7 +94,7 @@ HandlerResponse WSRequestHandler::HandleGetSourcesList(WSRequestHandler* req)
 * @return {Boolean} `ids.*.caps.doNotSelfMonitor` True if sources of this type may cause a feedback loop if it's audio is monitored and shouldn't be
 *
 * @api requests
-* @name GetSourcesTypesList
+* @name GetSourceTypesList
 * @category sources
 * @since 4.3.0
 */


### PR DESCRIPTION
The API call listed in the documentation doesn't work (tested on 4.3.1),
but without the 's', it works fine. Update documentation to match code.