### PR TITLE
Allow the manipulation of the locked flag of scene items.

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -15,6 +15,7 @@
         "{int} `crop.bottom` The number of pixels cropped off the bottom of the scene item before scaling.",
         "{int} `crop.left` The number of pixels cropped off the left of the scene item before scaling.",
         "{bool} `visible` If the scene item is visible.",
+        "{bool} `locked` If the scene item is locked in position.",
         "{String} `bounds.type` Type of bounding box. Can be \"OBS_BOUNDS_STRETCH\", \"OBS_BOUNDS_SCALE_INNER\", \"OBS_BOUNDS_SCALE_OUTER\", \"OBS_BOUNDS_SCALE_TO_WIDTH\", \"OBS_BOUNDS_SCALE_TO_HEIGHT\", \"OBS_BOUNDS_MAX_ONLY\" or \"OBS_BOUNDS_NONE\".",
         "{int} `bounds.alignment` Alignment of the bounding box.",
         "{double} `bounds.x` Width of the bounding box.",
@@ -79,6 +80,11 @@
           "type": "bool",
           "name": "visible",
           "description": "If the scene item is visible."
+        },
+        {
+          "type": "bool",
+          "name": "locked",
+          "description": "If the scene item is locked in position."
         },
         {
           "type": "String",
@@ -3432,6 +3438,7 @@
           "{int} `crop.left` The new amount of pixels cropped off the left of the source before scaling.",
           "{int} `crop.right` The new amount of pixels cropped off the right of the source before scaling.",
           "{bool} `visible` The new visibility of the source. 'true' shows source, 'false' hides source.",
+          "{bool} `locked` The new locked status of the source. 'true' keeps it in its current position, 'false' allows movement.",
           "{String} `bounds.type` The new bounds type of the source. Can be \"OBS_BOUNDS_STRETCH\", \"OBS_BOUNDS_SCALE_INNER\", \"OBS_BOUNDS_SCALE_OUTER\", \"OBS_BOUNDS_SCALE_TO_WIDTH\", \"OBS_BOUNDS_SCALE_TO_HEIGHT\", \"OBS_BOUNDS_MAX_ONLY\" or \"OBS_BOUNDS_NONE\".",
           "{int} `bounds.alignment` The new alignment of the bounding box. (0-2, 4-6, 8-10)",
           "{double} `bounds.x` The new width of the bounding box.",
@@ -3506,6 +3513,11 @@
             "type": "bool",
             "name": "visible",
             "description": "The new visibility of the source. 'true' shows source, 'false' hides source."
+          },
+          {
+            "type": "bool",
+            "name": "locked",
+            "description": "The new locked status of the source. 'true' keeps it in its current position, 'false' allows movement."
           },
           {
             "type": "String",

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -212,6 +212,7 @@ These are complex types, such as `Source` and `Scene`, which are used as argumen
 | `crop.bottom` | _int_ | The number of pixels cropped off the bottom of the scene item before scaling. |
 | `crop.left` | _int_ | The number of pixels cropped off the left of the scene item before scaling. |
 | `visible` | _bool_ | If the scene item is visible. |
+| `locked` | _bool_ | If the scene item is locked in position. |
 | `bounds.type` | _String_ | Type of bounding box. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE". |
 | `bounds.alignment` | _int_ | Alignment of the bounding box. |
 | `bounds.x` | _double_ | Width of the bounding box. |
@@ -1506,6 +1507,7 @@ Sets the scene specific properties of a source. Unspecified properties will rema
 | `crop.left` | _int_ | The new amount of pixels cropped off the left of the source before scaling. |
 | `crop.right` | _int_ | The new amount of pixels cropped off the right of the source before scaling. |
 | `visible` | _bool_ | The new visibility of the source. 'true' shows source, 'false' hides source. |
+| `locked` | _bool_ | The new locked status of the source. 'true' keeps it in its current position, 'false' allows movement. |
 | `bounds.type` | _String_ | The new bounds type of the source. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE". |
 | `bounds.alignment` | _int_ | The new alignment of the bounding box. (0-2, 4-6, 8-10) |
 | `bounds.x` | _double_ | The new width of the bounding box. |

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -127,6 +127,7 @@ obs_data_t* Utils::GetSceneItemData(obs_sceneitem_t* item) {
 	obs_data_set_double(data, "cx", item_width * scale.x);
 	obs_data_set_double(data, "cy", item_height * scale.y);
 	obs_data_set_bool(data, "render", obs_sceneitem_visible(item));
+	obs_data_set_bool(data, "locked", obs_sceneitem_locked(item));
 
 	return data;
 }
@@ -593,6 +594,7 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
  * @property {int} `crop.bottom` The number of pixels cropped off the bottom of the scene item before scaling.
  * @property {int} `crop.left` The number of pixels cropped off the left of the scene item before scaling.
  * @property {bool} `visible` If the scene item is visible.
+ * @property {bool} `locked` If the scene item is locked in position.
  * @property {String} `bounds.type` Type of bounding box. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE".
  * @property {int} `bounds.alignment` Alignment of the bounding box.
  * @property {double} `bounds.x` Width of the bounding box.
@@ -622,6 +624,7 @@ obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
 	uint32_t alignment = obs_sceneitem_get_alignment(sceneItem);
 	float rotation = obs_sceneitem_get_rot(sceneItem);
 	bool isVisible = obs_sceneitem_visible(sceneItem);
+	bool isLocked = obs_sceneitem_locked(sceneItem);
 
 	obs_bounds_type boundsType = obs_sceneitem_get_bounds_type(sceneItem);
 	uint32_t boundsAlignment = obs_sceneitem_get_bounds_alignment(sceneItem);
@@ -654,6 +657,7 @@ obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
 	obs_data_set_obj(data, "scale", scaleData);
 	obs_data_set_obj(data, "crop", cropData);
 	obs_data_set_bool(data, "visible", isVisible);
+	obs_data_set_bool(data, "locked", isLocked);
 	obs_data_set_obj(data, "bounds", boundsData);
 
 	obs_data_set_int(data, "sourceWidth", baseSourceWidth);

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -78,6 +78,7 @@ HandlerResponse WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler*
 * @param {int} `crop.left` The new amount of pixels cropped off the left of the source before scaling.
 * @param {int} `crop.right` The new amount of pixels cropped off the right of the source before scaling.
 * @param {bool} `visible` The new visibility of the source. 'true' shows source, 'false' hides source.
+* @param {bool} `locked` The new locked status of the source. 'true' keeps it in its current position, 'false' allows movement.
 * @param {String} `bounds.type` The new bounds type of the source. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE".
 * @param {int} `bounds.alignment` The new alignment of the bounding box. (0-2, 4-6, 8-10)
 * @param {double} `bounds.x` The new width of the bounding box.
@@ -179,6 +180,10 @@ HandlerResponse WSRequestHandler::HandleSetSceneItemProperties(WSRequestHandler*
 
 	if (req->hasField("visible")) {
 		obs_sceneitem_set_visible(sceneItem, obs_data_get_bool(req->data, "visible"));
+	}
+
+	if (req->hasField("locked")) {
+		obs_sceneitem_set_locked(sceneItem, obs_data_get_bool(req->data, "locked"));
 	}
 
 	if (req->hasField("bounds")) {


### PR DESCRIPTION
Lockedness can be seen when you query an item or see the scene
contents, and can be changed (only) with SetSceneItemProperties.