### PR TITLE
Source Image Snapshot

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -85,6 +85,7 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "GetSourceTypesList", WSRequestHandler::HandleGetSourceTypesList },
 	{ "GetSourceSettings", WSRequestHandler::HandleGetSourceSettings },
 	{ "SetSourceSettings", WSRequestHandler::HandleSetSourceSettings },
+	{ "GetSourceImage", WSRequestHandler::HandleGetSourceImage },
 
 	{ "GetSourceFilters", WSRequestHandler::HandleGetSourceFilters },
 	{ "AddFilterToSource", WSRequestHandler::HandleAddFilterToSource },

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -85,7 +85,7 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "GetSourceTypesList", WSRequestHandler::HandleGetSourceTypesList },
 	{ "GetSourceSettings", WSRequestHandler::HandleGetSourceSettings },
 	{ "SetSourceSettings", WSRequestHandler::HandleSetSourceSettings },
-	{ "GetSourceImage", WSRequestHandler::HandleGetSourceImage },
+	{ "TakeSourceScreenshot", WSRequestHandler::HandleTakeSourceScreenshot },
 
 	{ "GetSourceFilters", WSRequestHandler::HandleGetSourceFilters },
 	{ "AddFilterToSource", WSRequestHandler::HandleAddFilterToSource },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -116,7 +116,7 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleGetSourceTypesList(WSRequestHandler* req);
 		static HandlerResponse HandleGetSourceSettings(WSRequestHandler* req);
 		static HandlerResponse HandleSetSourceSettings(WSRequestHandler* req);
-		static void HandleGetSourceImage(WSRequestHandler* req);
+		static HandlerResponse HandleGetSourceImage(WSRequestHandler* req);
 
 		static HandlerResponse HandleGetSourceFilters(WSRequestHandler* req);
 		static HandlerResponse HandleAddFilterToSource(WSRequestHandler* req);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -116,7 +116,7 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleGetSourceTypesList(WSRequestHandler* req);
 		static HandlerResponse HandleGetSourceSettings(WSRequestHandler* req);
 		static HandlerResponse HandleSetSourceSettings(WSRequestHandler* req);
-		static HandlerResponse HandleGetSourceImage(WSRequestHandler* req);
+		static HandlerResponse HandleTakeSourceScreenshot(WSRequestHandler* req);
 
 		static HandlerResponse HandleGetSourceFilters(WSRequestHandler* req);
 		static HandlerResponse HandleAddFilterToSource(WSRequestHandler* req);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -116,6 +116,7 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleGetSourceTypesList(WSRequestHandler* req);
 		static HandlerResponse HandleGetSourceSettings(WSRequestHandler* req);
 		static HandlerResponse HandleSetSourceSettings(WSRequestHandler* req);
+		static void HandleGetSourceImage(WSRequestHandler* req);
 
 		static HandlerResponse HandleGetSourceFilters(WSRequestHandler* req);
 		static HandlerResponse HandleAddFilterToSource(WSRequestHandler* req);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1345,6 +1345,7 @@ HandlerResponse WSRequestHandler::HandleSetSourceFilterSettings(WSRequestHandler
 *
 * @param {String} `sourceName` Source name
 * @param {String} `pictureFormat` Format of the encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)
+* @param {String (optional)} `saveToFilePath` Full file path (file extension included) where the captured image is to be saved. Can be in a format different from `pictureFormat`.
 * @param {int (optional)} `width` Screenshot width. Defaults to the source's base width.
 * @param {int (optional)} `height` Screenshot height. Defaults to the source's base height.
 *
@@ -1453,6 +1454,11 @@ HandlerResponse WSRequestHandler::HandleTakeSourceScreenshot(WSRequestHandler* r
 	buffer.open(QBuffer::WriteOnly);
 	sourceImage.save(&buffer, pictureFormat);
 	buffer.close();
+
+	if (req->hasField("saveToFilePath")) {
+		QString imageFilePath = obs_data_get_string(req->data, "saveToFilePath");
+		sourceImage.save(imageFilePath);
+	}
 
 	QString imgBase64(encodedImgBytes.toBase64());
 	imgBase64.prepend(

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1430,7 +1430,7 @@ HandlerResponse WSRequestHandler::HandleTakeSourceScreenshot(WSRequestHandler* r
 		if (gs_stagesurface_map(stagesurface, &videoData, &videoLinesize)) {
 			int linesize = sourceImage.bytesPerLine();
 			for (int y = 0; y < imgHeight; y++) {
-				memcpy(sourceImage.scanLine(y), videoData + (y * linesize), linesize);
+			 	memcpy(sourceImage.scanLine(y), videoData + (y * videoLinesize), linesize);
 			}
 			gs_stagesurface_unmap(stagesurface);
 			renderSuccess = true;

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1398,7 +1398,7 @@ HandlerResponse WSRequestHandler::HandleGetSourceImage(WSRequestHandler* req) {
 	QByteArray encodedImgBytes;
 	QBuffer buffer(&encodedImgBytes);
 	buffer.open(QBuffer::WriteOnly);
-	sourceImage.save(&buffer, "WEBP", 50);
+	sourceImage.save(&buffer, "PNG", 50);
 	buffer.close();
 
 	QString imgBase64(encodedImgBytes.toBase64());
@@ -1406,6 +1406,6 @@ HandlerResponse WSRequestHandler::HandleGetSourceImage(WSRequestHandler* req) {
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
-	obs_data_set_string(response, "img", imgBase64.toUtf8().constData());
+	obs_data_set_string(response, "img", imgBase64.toUtf8());
 	return req->SendOKResponse(response);
 }

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1356,11 +1356,12 @@ HandlerResponse WSRequestHandler::HandleGetSourceImage(WSRequestHandler* req) {
 	uint8_t* videoData = nullptr;
 	uint32_t videoLinesize = 0;
 
+	// TODO asynchronous rendering and encoding
 	obs_enter_graphics();
 
 	gs_texrender_t* texrender = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
 	gs_stagesurf_t* stagesurface = gs_stagesurface_create(imgWidth, imgHeight, GS_RGBA);
-	
+
 	bool renderSuccess = false;
 	gs_texrender_reset(texrender);
 	if (gs_texrender_begin(texrender, imgWidth, imgHeight)) {

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1345,7 +1345,7 @@ HandlerResponse WSRequestHandler::HandleSetSourceFilterSettings(WSRequestHandler
 *
 * @param {String} `sourceName` Source name
 * @param {String} `pictureFormat` Format of the encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)
-* @param {int (optional)} `width` Screenshot width. Defaults to the source's base width. 
+* @param {int (optional)} `width` Screenshot width. Defaults to the source's base width.
 * @param {int (optional)} `height` Screenshot height. Defaults to the source's base height.
 *
 * @return {String} `sourceName` Source name
@@ -1404,7 +1404,6 @@ HandlerResponse WSRequestHandler::HandleTakeSourceScreenshot(WSRequestHandler* r
 	uint8_t* videoData = nullptr;
 	uint32_t videoLinesize = 0;
 
-	// TODO asynchronous rendering and encoding
 	obs_enter_graphics();
 
 	gs_texrender_t* texrender = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
@@ -1447,7 +1446,7 @@ HandlerResponse WSRequestHandler::HandleTakeSourceScreenshot(WSRequestHandler* r
 	QByteArray encodedImgBytes;
 	QBuffer buffer(&encodedImgBytes);
 	buffer.open(QBuffer::WriteOnly);
-	sourceImage.save(&buffer, pictureFormat, 50);
+	sourceImage.save(&buffer, pictureFormat);
 	buffer.close();
 
 	QString imgBase64(encodedImgBytes.toBase64());

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1349,7 +1349,6 @@ HandlerResponse WSRequestHandler::HandleSetSourceFilterSettings(WSRequestHandler
 * Clients can specify `width` and `height` parameters to receive scaled pictures. Aspect ratio is
 * preserved if only one of these two parameters is specified.
 *
-*
 * @param {String} `sourceName` Source name
 * @param {String (optional)} `embedPictureFormat` Format of the Data URI encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)
 * @param {String (optional)} `saveToFilePath` Full file path (file extension included) where the captured image is to be saved. Can be in a format different from `pictureFormat`. Can be a relative path.

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1395,18 +1395,18 @@ void WSRequestHandler::HandleGetSourceImage(WSRequestHandler* req) {
 	if (renderSuccess) {
 		QImage sourceImage(imgBuf, imgWidth, imgHeight, QImage::Format::Format_RGBA8888);
 		
-		QByteArray pngBytes;
-		QBuffer pngBytesBuf(&pngBytes);
-		pngBytesBuf.open(QBuffer::ReadWrite);
-		sourceImage.save(&pngBytesBuf, "PNG");
-		pngBytesBuf.close();
+		QByteArray encodedImgBytes;
+		QBuffer buffer(&encodedImgBytes);
+		buffer.open(QBuffer::WriteOnly);
+		sourceImage.save(&buffer, "WEBP", 0);
+		buffer.close();
 
-		QString pngBase64(pngBytes.toBase64());
-		pngBase64.prepend("data:image/png;base64,");
+		QString imgBase64(encodedImgBytes.toBase64());
+		imgBase64.prepend("data:image/webp;base64,");
 
 		OBSDataAutoRelease response = obs_data_create();
 		obs_data_set_string(response, "sourceName", obs_source_get_name(source));
-		obs_data_set_string(response, "img", pngBase64.toUtf8().constData());
+		obs_data_set_string(response, "img", imgBase64.toUtf8().constData());
 		req->SendOKResponse(response);
 	} else {
 		req->SendErrorResponse("Source render failed.");

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1421,7 +1421,9 @@ HandlerResponse WSRequestHandler::HandleTakeSourceScreenshot(WSRequestHandler* r
 		gs_blend_state_push();
 		gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
 
+		obs_source_inc_showing(source);
 		obs_source_video_render(source);
+		obs_source_dec_showing(source);
 
 		gs_blend_state_pop();
 		gs_texrender_end(texrender);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1403,7 +1403,7 @@ HandlerResponse WSRequestHandler::HandleGetSourceImage(WSRequestHandler* req) {
 	buffer.close();
 
 	QString imgBase64(encodedImgBytes.toBase64());
-	imgBase64.prepend("data:image/webp;base64,");
+	imgBase64.prepend("data:image/png;base64,");
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "sourceName", obs_source_get_name(source));

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1,6 +1,7 @@
-#include <QString>
-#include <QImage>
-#include <QBuffer>
+#include <QtCore/QString>
+#include <QtCore/QBuffer>
+#include <QtGui/QImage>
+
 #include "Utils.h"
 
 #include "WSRequestHandler.h"

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1348,11 +1348,11 @@ HandlerResponse WSRequestHandler::HandleSetSourceFilterSettings(WSRequestHandler
 * @return {String} `img` Image Data URI
 *
 * @api requests
-* @name GetSourceImage
+* @name TakeSourceScreenshot
 * @category sources
 * @since 4.6.0
 */
-HandlerResponse WSRequestHandler::HandleGetSourceImage(WSRequestHandler* req) {
+HandlerResponse WSRequestHandler::HandleTakeSourceScreenshot(WSRequestHandler* req) {
 	if (!req->hasField("sourceName") || !req->hasField("pictureFormat")) {
 		return req->SendErrorResponse("missing request parameters");
 	}

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -1339,12 +1339,14 @@ HandlerResponse WSRequestHandler::HandleSetSourceFilterSettings(WSRequestHandler
 }
 
 /**
-* Take a picture snapshot of a source and sends it in the response a Data URI (base64-encoded data)
+* Takes a picture snapshot of a source and sends it in the response a Data URI (base64-encoded data)
+* Clients can specify `width` and `height` parameters to receive scaled pictures. Aspect ratio is
+* preserved if only one of these two parameters is specified.
 *
 * @param {String} `sourceName` Source name
 * @param {String} `pictureFormat` Format of the encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)
-* @param {int (optional)} `width` Screenshot width. Defaults to the source's base width.
-* @param {int (optional)} `height` Screenshot height. Defaults to the source's base heigh.
+* @param {int (optional)} `width` Screenshot width. Defaults to the source's base width. 
+* @param {int (optional)} `height` Screenshot height. Defaults to the source's base height.
 *
 * @return {String} `sourceName` Source name
 * @return {String} `img` Image Data URI


### PR DESCRIPTION
Provides a new `GetSourceImage` method that:

- Takes an image snapshot of the specified source
- Encodes it as a PNG and/or WebP picture and sends it to the WebSocket client as a base64 data URI

Todo: 

- [x] Codec selection: choose between PNG, JPEG or BMP
- [X] ~~Asynchronous rendering and encoding (from the server's perspective, to avoid blocking its event loop)~~ Done in #312 
- [x] Direct save to file

Closes #169 