### PR TITLE
Return nullptr if there are no tray icons

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -390,7 +390,8 @@ QSystemTrayIcon* Utils::GetTrayIcon() {
 	QMainWindow* main = (QMainWindow*)obs_frontend_get_main_window();
 	if (!main) return nullptr;
 
-	return main->findChildren<QSystemTrayIcon*>().first();
+	QList<QSystemTrayIcon*> trays = main->findChildren<QSystemTrayIcon*>();
+	return trays.isEmpty() ? nullptr : trays.first();
 }
 
 void Utils::SysTrayNotify(QString text,


### PR DESCRIPTION
After upgrading both OBS and obs-websocket, I got segfaults every time a websocket client connected. My analysis pointed to a problem in Utils.cpp GetTrayIcon returning a non-null but invalid pointer (0x20 in my tests), which appeared to happen when there was no system tray icon.

Not sure if this is a true fix or not, but it does appear to stop the crashes.