### PR TITLE
Groups fixes

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -198,10 +198,6 @@ obs_sceneitem_t* Utils::GetSceneItemFromName(obs_source_t* source, QString name)
 			return false;
 		}
 
-		if (obs_sceneitem_is_group(currentItem)) {
-
-		}
-
 		return true;
 	}, &search);
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -111,7 +111,6 @@ obs_data_array_t* Utils::GetSceneItems(obs_source_t* source) {
  * @property {Number} `volume`
  * @property {Number} `x`
  * @property {Number} `y`
- * @property {Boolean} `isGroup` Whether or not this Scene Item is a group
  * @property {String (optional)} `parentGroupName` Name of the item's parent (if this item belongs to a group)
  * @property {Array<SceneItem> (optional)} `groupChildren` List of children (if this item is a group)
  */
@@ -148,7 +147,6 @@ obs_data_t* Utils::GetSceneItemData(obs_sceneitem_t* item) {
 	obs_data_set_double(data, "cy", item_height * scale.y);
 	obs_data_set_bool(data, "render", obs_sceneitem_visible(item));
 	obs_data_set_bool(data, "locked", obs_sceneitem_locked(item));
-	obs_data_set_bool(data, "isGroup", obs_sceneitem_is_group(item));
 
 	obs_scene_t* parent = obs_sceneitem_get_scene(item);
 	if (parent) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,14 +28,14 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "Config.h"
 
 /**
-* @typedef {Object} `Source` An OBS Scene Item.
+* @typedef {Object} `SceneItem` An OBS Scene Item.
 * @property {Number} `cy`
 * @property {Number} `cx`
 * @property {String} `name` The name of this Scene Item.
 * @property {int} `id` Scene item ID
 * @property {Boolean} `render` Whether or not this Scene Item is set to "visible".
 * @property {Boolean} `locked` Whether or not this Scene Item is locked and can't be moved around
-* @property {Boolean} `isGroup` Whether or not this Scene Item is a group
+* @property {Boolean} `isGroup` Whether or not this Scene Item is a group 
 * @property {Number} `source_cx`
 * @property {Number} `source_cy`
 * @property {String} `type` Source type. Value is one of the following: "input", "filter", "transition", "scene" or "unknown"

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -27,6 +27,23 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "Utils.h"
 #include "Config.h"
 
+/**
+* @typedef {Object} `Source` An OBS Scene Item.
+* @property {Number} `cy`
+* @property {Number} `cx`
+* @property {String} `name` The name of this Scene Item.
+* @property {int} `id` Scene item ID
+* @property {Boolean} `render` Whether or not this Scene Item is set to "visible".
+* @property {Boolean} `locked` Whether or not this Scene Item is locked and can't be moved around
+* @property {Boolean} `isGroup` Whether or not this Scene Item is a group
+* @property {Number} `source_cx`
+* @property {Number} `source_cy`
+* @property {String} `type` Source type. Value is one of the following: "input", "filter", "transition", "scene" or "unknown"
+* @property {Number} `volume`
+* @property {Number} `x`
+* @property {Number} `y`
+*/
+
 Q_DECLARE_METATYPE(OBSScene);
 
 const QHash<obs_bounds_type, QString> boundTypeNames = {
@@ -130,6 +147,7 @@ obs_data_t* Utils::GetSceneItemData(obs_sceneitem_t* item) {
 	obs_data_set_double(data, "cy", item_height * scale.y);
 	obs_data_set_bool(data, "render", obs_sceneitem_visible(item));
 	obs_data_set_bool(data, "locked", obs_sceneitem_locked(item));
+	obs_data_set_bool(data, "isGroup", obs_sceneitem_is_group(item));
 
 	return data;
 }
@@ -178,6 +196,10 @@ obs_sceneitem_t* Utils::GetSceneItemFromName(obs_source_t* source, QString name)
 			search->result = currentItem;
 			obs_sceneitem_addref(search->result);
 			return false;
+		}
+
+		if (obs_sceneitem_is_group(currentItem)) {
+
 		}
 
 		return true;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -657,8 +657,8 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
  * @property {int} `sourceHeight` Base source (without scaling) of the source
  * @property {double} `width` Scene item width (base source width multiplied by the horizontal scaling factor)
  * @property {double} `height` Scene item height (base source height multiplied by the vertical scaling factor)
- * @property {String} `parentGroupName` Name of the item's parent (if this item belongs to a group)
- * @property {Array<SceneItemTransform>} `groupChildren` List of children (if this item is a group) 
+ * @property {String (optional)} `parentGroupName` Name of the item's parent (if this item belongs to a group)
+ * @property {Array<SceneItemTransform> (optional)} `groupChildren` List of children (if this item is a group) 
  */
 obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
 	if (!sceneItem) {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -658,7 +658,7 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
  * @property {double} `width` Scene item width (base source width multiplied by the horizontal scaling factor)
  * @property {double} `height` Scene item height (base source height multiplied by the vertical scaling factor)
  * @property {String} `parentGroupName` Name of the item's parent (if this item belongs to a group)
- * @property {Array<SceneItemTransform>} `groupChildren` 
+ * @property {Array<SceneItemTransform>} `groupChildren` List of children (if this item is a group) 
  */
 obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
 	if (!sceneItem) {

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -344,7 +344,7 @@ const char* WSEvents::GetRecordingTimecode() {
  * Indicates a scene change.
  *
  * @return {String} `scene-name` The new scene.
- * @return {Array<Source>} `sources` List of sources in the new scene. Same specification as [`GetCurrentScene`](#getcurrentscene).
+ * @return {Array<SceneItem>} `sources` List of scene items in the new scene. Same specification as [`GetCurrentScene`](#getcurrentscene).
  *
  * @api events
  * @name SwitchScenes
@@ -1435,7 +1435,7 @@ void WSEvents::OnSceneItemDeselected(void* param, calldata_t* data) {
  * The selected preview scene has changed (only available in Studio Mode).
  *
  * @return {String} `scene-name` Name of the scene being previewed.
- * @return {Array<Source>} `sources` List of sources composing the scene. Same specification as [`GetCurrentScene`](#getcurrentscene).
+ * @return {Array<SceneItem>} `sources` List of sources composing the scene. Same specification as [`GetCurrentScene`](#getcurrentscene).
  *
  * @api events
  * @name PreviewSceneChanged

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -29,7 +29,6 @@
 * @return {int} `sourceHeight` Base source (without scaling) of the source
 * @return {double} `width` Scene item width (base source width multiplied by the horizontal scaling factor)
 * @return {double} `height` Scene item height (base source height multiplied by the vertical scaling factor)
-* @property {Boolean} `isGroup` Whether or not this Scene Item is a group
 * @property {String (optional)} `parentGroupName` Name of the item's parent (if this item belongs to a group)
 * @property {Array<SceneItemTransform> (optional)} `groupChildren` List of children (if this item is a group)
 * 

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -30,8 +30,8 @@
 * @return {double} `width` Scene item width (base source width multiplied by the horizontal scaling factor)
 * @return {double} `height` Scene item height (base source height multiplied by the vertical scaling factor)
 * @property {Boolean} `isGroup` Whether or not this Scene Item is a group
-* @property {String} `parentGroupName` Name of the item's parent (if this item belongs to a group)
-* @property {Array<SceneItemTransform>} `groupChildren` List of children (if this item is a group)
+* @property {String (optional)} `parentGroupName` Name of the item's parent (if this item belongs to a group)
+* @property {Array<SceneItemTransform> (optional)} `groupChildren` List of children (if this item is a group)
 * 
 * @api requests
 * @name GetSceneItemProperties

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -29,6 +29,9 @@
 * @return {int} `sourceHeight` Base source (without scaling) of the source
 * @return {double} `width` Scene item width (base source width multiplied by the horizontal scaling factor)
 * @return {double} `height` Scene item height (base source height multiplied by the vertical scaling factor)
+* @property {Boolean} `isGroup` Whether or not this Scene Item is a group
+* @property {String} `parentGroupName` Name of the item's parent (if this item belongs to a group)
+* @property {Array<SceneItemTransform>} `groupChildren` List of children (if this item is a group)
 * 
 * @api requests
 * @name GetSceneItemProperties

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -4,6 +4,7 @@
 
 /**
 * Gets the scene specific properties of the specified source item.
+* Coordinates are relative to the item's parent (the scene or group it belongs to).
 *
 * @param {String (optional)} `scene-name` the name of the scene that the source item belongs to. Defaults to the current scene.
 * @param {String} `item` The name of the source.
@@ -67,6 +68,7 @@ HandlerResponse WSRequestHandler::HandleGetSceneItemProperties(WSRequestHandler*
 
 /**
 * Sets the scene specific properties of a source. Unspecified properties will remain unchanged.
+* Coordinates are relative to the item's parent (the scene or group it belongs to).
 *
 * @param {String (optional)} `scene-name` the name of the scene that the source item belongs to. Defaults to the current scene.
 * @param {String} `item` The name of the source.

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -3,22 +3,6 @@
 #include "WSRequestHandler.h"
 
 /**
-* @typedef {Object} `Source` An OBS Scene Item.
-* @property {Number} `cy`
-* @property {Number} `cx`
-* @property {String} `name` The name of this Scene Item.
-* @property {int} `id` Scene item ID
-* @property {Boolean} `render` Whether or not this Scene Item is set to "visible".
-* @property {Boolean} `locked` Whether or not this Scene Item is locked and can't be moved around
-* @property {Number} `source_cx`
-* @property {Number} `source_cy`
-* @property {String} `type` Source type. Value is one of the following: "input", "filter", "transition", "scene" or "unknown"
-* @property {Number} `volume`
-* @property {Number} `x`
-* @property {Number} `y`
-*/
-
-/**
 * Gets the scene specific properties of the specified source item.
 *
 * @param {String (optional)} `scene-name` the name of the scene that the source item belongs to. Defaults to the current scene.

--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -5,7 +5,7 @@
 /**
 * @typedef {Object} `Scene`
 * @property {String} `name` Name of the currently active scene.
-* @property {Array<Source>} `sources` Ordered list of the current scene's source items.
+* @property {Array<SceneItem>} `sources` Ordered list of the current scene's source items.
 */
 
 /**
@@ -38,7 +38,7 @@ HandlerResponse WSRequestHandler::HandleSetCurrentScene(WSRequestHandler* req) {
  * Get the current scene's name and source items.
  * 
  * @return {String} `name` Name of the currently active scene.
- * @return {Array<Source>} `sources` Ordered list of the current scene's source items.
+ * @return {Array<SceneItem>} `sources` Ordered list of the current scene's source items.
  *
  * @api requests
  * @name GetCurrentScene

--- a/src/WSRequestHandler_StudioMode.cpp
+++ b/src/WSRequestHandler_StudioMode.cpp
@@ -26,7 +26,7 @@ HandlerResponse WSRequestHandler::HandleGetStudioModeStatus(WSRequestHandler* re
  * Will return an `error` if Studio Mode is not enabled.
  *
  * @return {String} `name` The name of the active preview scene.
- * @return {Array<Source>} `sources`
+ * @return {Array<SceneItem>} `sources`
  *
  * @api requests
  * @name GetPreviewScene


### PR DESCRIPTION
- [x] Fix scene item retrieval in requests: GetSceneItemProperties, SetSceneItemProperties, ResetSceneItem, DeleteSceneItem, DuplicateSceneItem
    - Bonus: fix deprecated request types: SetSceneItemRender, SetSceneItemPosition, SetSceneItemTransform, SetSceneItemCrop
- [x] Scene Item info: add a `parentGroupName` property
- [x] Scene Item Transform info: add a `parentGroupName` property
- [x] Scene Item info: add a `groupChildren` array property
- [x] Scene Item Transform info: add a `groupChildren` array property

Fixes #237 