### PR TITLE
Create a command for opening a projector.

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -3287,6 +3287,67 @@
         "lead": "",
         "type": "class",
         "examples": []
+      },
+      {
+        "subheads": [],
+        "description": "Open a projector window or create a projector on a monitor. Requires OBS v24.0.4 or newer.",
+        "param": [
+          "{String (Optional)} `type` Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive).",
+          "{int (Optional)} `monitor` Monitor to open the projector on. If -1 or omitted, opens a window.",
+          "{String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in base 64.",
+          "{String (Optional)} `name` Name of the source or scene to be displayed (ignored for other projector types)."
+        ],
+        "api": "requests",
+        "name": "OpenProjector",
+        "category": "general",
+        "since": "4.7.0",
+        "params": [
+          {
+            "type": "String (Optional)",
+            "name": "type",
+            "description": "Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive)."
+          },
+          {
+            "type": "int (Optional)",
+            "name": "monitor",
+            "description": "Monitor to open the projector on. If -1 or omitted, opens a window."
+          },
+          {
+            "type": "String (Optional)",
+            "name": "geometry",
+            "description": "Size and position of the projector window (only if monitor is -1). Encoded in base 64."
+          },
+          {
+            "type": "String (Optional)",
+            "name": "name",
+            "description": "Name of the source or scene to be displayed (ignored for other projector types)."
+          }
+        ],
+        "names": [
+          {
+            "name": "",
+            "description": "OpenProjector"
+          }
+        ],
+        "categories": [
+          {
+            "name": "",
+            "description": "general"
+          }
+        ],
+        "sinces": [
+          {
+            "name": "",
+            "description": "4.7.0"
+          }
+        ],
+        "heading": {
+          "level": 2,
+          "text": "OpenProjector"
+        },
+        "lead": "",
+        "type": "class",
+        "examples": []
       }
     ],
     "outputs": [

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -118,6 +118,7 @@ auth_response = base64_encode(auth_response_hash)
     + [GetStats](#getstats)
     + [BroadcastCustomMessage](#broadcastcustommessage-1)
     + [GetVideoInfo](#getvideoinfo)
+    + [OpenProjector](#openprojector)
   * [Outputs](#outputs)
     + [ListOutputs](#listoutputs)
     + [GetOutputInfo](#getoutputinfo)
@@ -1331,6 +1332,29 @@ _No specified parameters._
 | `colorSpace` | _String_ | Color space for YUV |
 | `colorRange` | _String_ | Color range (full or partial) |
 
+
+---
+
+### OpenProjector
+
+
+- Added in v4.7.0
+
+Open a projector window or create a projector on a monitor. Requires OBS v24.0.4 or newer.
+
+**Request Fields:**
+
+| Name | Type  | Description |
+| ---- | :---: | ------------|
+| `type` | _String (Optional)_ | Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive). |
+| `monitor` | _int (Optional)_ | Monitor to open the projector on. If -1 or omitted, opens a window. |
+| `geometry` | _String (Optional)_ | Size and position of the projector window (only if monitor is -1). Encoded in base 64. |
+| `name` | _String (Optional)_ | Name of the source or scene to be displayed (ignored for other projector types). |
+
+
+**Response Items:**
+
+_No additional response items._
 
 ---
 

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -32,6 +32,7 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "GetStats", WSRequestHandler::HandleGetStats },
 	{ "SetHeartbeat", WSRequestHandler::HandleSetHeartbeat },
 	{ "GetVideoInfo", WSRequestHandler::HandleGetVideoInfo },
+	{ "OpenProjector", WSRequestHandler::HandleOpenProjector },
 
 	{ "SetFilenameFormatting", WSRequestHandler::HandleSetFilenameFormatting },
 	{ "GetFilenameFormatting", WSRequestHandler::HandleGetFilenameFormatting },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -79,6 +79,7 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleGetStats(WSRequestHandler* req);
 		static HandlerResponse HandleSetHeartbeat(WSRequestHandler* req);
 		static HandlerResponse HandleGetVideoInfo(WSRequestHandler* req);
+		static HandlerResponse HandleOpenProjector(WSRequestHandler* req);
 
 		static HandlerResponse HandleSetFilenameFormatting(WSRequestHandler* req);
 		static HandlerResponse HandleGetFilenameFormatting(WSRequestHandler* req);

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -300,7 +300,7 @@ HandlerResponse WSRequestHandler::HandleGetVideoInfo(WSRequestHandler* req) {
 }
 
 /**
- * Open a projector window or create a projector on a monitor.
+ * Open a projector window or create a projector on a monitor. Requires OBS v24.0.4 or newer.
  * 
  * @param {String (Optional)} `type` Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive).
  * @param {int (Optional)} `monitor` Monitor to open the projector on. If -1 or omitted, opens a window.
@@ -313,7 +313,7 @@ HandlerResponse WSRequestHandler::HandleGetVideoInfo(WSRequestHandler* req) {
  * @since 4.7.0 
  */
 HandlerResponse WSRequestHandler::HandleOpenProjector(WSRequestHandler* req) {
-	#if LIBOBS_API_VER >= 0x18000003
+	#if LIBOBS_API_VER >= 0x18000004
 	const char *type = obs_data_get_string(req->data, "type");
 	int monitor = -1;
 	if (req->hasField("monitor")) {
@@ -324,6 +324,6 @@ HandlerResponse WSRequestHandler::HandleOpenProjector(WSRequestHandler* req) {
 	obs_frontend_open_projector(type, monitor, geometry, name);
 	return req->SendOKResponse();
 	#else
-	return req->SendErrorResponse("Projector opening requires libobs v21.0.3 or newer.");
+	return req->SendErrorResponse("Projector opening requires libobs v21.0.4 or newer.");
 	#endif
 }

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -310,13 +310,13 @@ RpcResponse WSRequestHandler::GetVideoInfo(const RpcRequest& request) {
  * 
  * @param {String (Optional)} `type` Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive).
  * @param {int (Optional)} `monitor` Monitor to open the projector on. If -1 or omitted, opens a window.
- * @param {String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in base 64.
+ * @param {String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in base 64. Corresponds to OBS's saved projectors.
  * @param {String (Optional)} `name` Name of the source or scene to be displayed (ignored for other projector types).
  * 
  * @api requests
  * @name OpenProjector
  * @category general
- * @since unreleased 
+ * @since unreleased
  */
 RpcResponse WSRequestHandler::OpenProjector(const RpcRequest& request) {
 #if LIBOBS_API_VER >= 0x18000004

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -316,10 +316,10 @@ RpcResponse WSRequestHandler::GetVideoInfo(const RpcRequest& request) {
  * @api requests
  * @name OpenProjector
  * @category general
- * @since 4.7.0 
+ * @since unreleased 
  */
 RpcResponse WSRequestHandler::OpenProjector(const RpcRequest& request) {
-	#if LIBOBS_API_VER >= 0x18000004
+#if LIBOBS_API_VER >= 0x18000004
 	const char *type = obs_data_get_string(request.parameters(), "type");
 	int monitor = -1;
 	if (request.hasField("monitor")) {
@@ -329,7 +329,7 @@ RpcResponse WSRequestHandler::OpenProjector(const RpcRequest& request) {
 	const char *name = obs_data_get_string(request.parameters(), "name");
 	obs_frontend_open_projector(type, monitor, geometry, name);
 	return request.success();
-	#else
+#else
 	return request.failed("Projector opening requires libobs v24.0.4 or newer.");
-	#endif
+#endif
 }

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -324,6 +324,6 @@ HandlerResponse WSRequestHandler::HandleOpenProjector(WSRequestHandler* req) {
 	obs_frontend_open_projector(type, monitor, geometry, name);
 	return req->SendOKResponse();
 	#else
-	return req->SendErrorResponse("Projector opening requires libobs v21.0.4 or newer.");
+	return req->SendErrorResponse("Projector opening requires libobs v24.0.4 or newer.");
 	#endif
 }

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -298,3 +298,28 @@ HandlerResponse WSRequestHandler::HandleGetVideoInfo(WSRequestHandler* req) {
 	obs_data_set_string(response, "scaleType", describe_scale_type(ovi.scale_type));
 	return req->SendOKResponse(response);
 }
+
+/**
+ * Open a projector window or create a projector on a monitor.
+ * 
+ * @param {String (Optional)} `type` Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive).
+ * @param {int (Optional)} `monitor` Monitor to open the projector on. If -1 or omitted, opens a window.
+ * @param {String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in base 64.
+ * @param {String (Optional)} `name` Name of the source or scene to be displayed (ignored for other projector types).
+ * 
+ * @api requests
+ * @name OpenProjector
+ * @category general
+ * @since 4.7.0 
+ */
+HandlerResponse WSRequestHandler::HandleOpenProjector(WSRequestHandler* req) {
+	const char *type = obs_data_get_string(req->data, "type");
+	int monitor = -1;
+	if (req->hasField("monitor")) {
+		monitor = obs_data_get_int(req->data, "monitor");
+	}
+	const char *geometry = obs_data_get_string(req->data, "geometry");
+	const char *name = obs_data_get_string(req->data, "name");
+	obs_frontend_open_projector(type, monitor, geometry, name);
+	return req->SendOKResponse();
+}

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -310,7 +310,7 @@ RpcResponse WSRequestHandler::GetVideoInfo(const RpcRequest& request) {
  * 
  * @param {String (Optional)} `type` Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive).
  * @param {int (Optional)} `monitor` Monitor to open the projector on. If -1 or omitted, opens a window.
- * @param {String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in base 64. Corresponds to OBS's saved projectors.
+ * @param {String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in Base64 using Qt's geometry encoding (https://doc.qt.io/qt-5/qwidget.html#saveGeometry). Corresponds to OBS's saved projectors.
  * @param {String (Optional)} `name` Name of the source or scene to be displayed (ignored for other projector types).
  * 
  * @api requests

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -313,6 +313,7 @@ HandlerResponse WSRequestHandler::HandleGetVideoInfo(WSRequestHandler* req) {
  * @since 4.7.0 
  */
 HandlerResponse WSRequestHandler::HandleOpenProjector(WSRequestHandler* req) {
+	#if LIBOBS_API_VER >= 0x18000003
 	const char *type = obs_data_get_string(req->data, "type");
 	int monitor = -1;
 	if (req->hasField("monitor")) {
@@ -322,4 +323,7 @@ HandlerResponse WSRequestHandler::HandleOpenProjector(WSRequestHandler* req) {
 	const char *name = obs_data_get_string(req->data, "name");
 	obs_frontend_open_projector(type, monitor, geometry, name);
 	return req->SendOKResponse();
+	#else
+	return req->SendErrorResponse("Projector opening requires libobs v21.0.3 or newer.");
+	#endif
 }


### PR DESCRIPTION
Depends on obs-studio#1910 for back end functionality.

Is there a convenient and safe way to have this return a tidy error message if OBS doesn't support obs_frontend_open_projector()?

Closes #214 