### PR TITLE
Make it possible to broadcast messages (data) to other websocket clients

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -1506,6 +1506,25 @@ void WSEvents::OnStudioModeSwitched(bool checked) {
 }
 
 /**
+ * A custom broadcast message was received
+ *
+ * @param {String} `realm` Identifier provided by the sender
+ * @param {Object} `data` User-defined data
+ *
+ * @api events
+ * @name BroadcastCustomMessage
+ * @category general
+ * @since 4.7.0
+ */
+void WSEvents::OnBroadcastCustomMessage(QString realm, OBSDataAutoRelease data) {
+	OBSDataAutoRelease broadcastData = obs_data_create();
+	obs_data_set_string(broadcastData, "realm", realm.toUtf8().constData());
+	obs_data_set_obj(broadcastData, "data", data);
+
+	broadcastUpdate("BroadcastCustomMessage", broadcastData);
+}
+
+/**
  * @typedef {Object} `OBSStats`
  * @property {double} `fps` Current framerate.
  * @property {int} `render-total-frames` Number of frames rendered

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -1516,7 +1516,7 @@ void WSEvents::OnStudioModeSwitched(bool checked) {
  * @category general
  * @since 4.7.0
  */
-void WSEvents::OnBroadcastCustomMessage(QString realm, OBSDataAutoRelease data) {
+void WSEvents::OnBroadcastCustomMessage(QString realm, obs_data_t* data) {
 	OBSDataAutoRelease broadcastData = obs_data_create();
 	obs_data_set_string(broadcastData, "realm", realm.toUtf8().constData());
 	obs_data_set_obj(broadcastData, "data", data);

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -49,6 +49,9 @@ public:
 	const char* GetRecordingTimecode();
 	obs_data_t* GetStats();
 
+	void broadcastUpdate(const char* updateType,
+		obs_data_t* additionalFields);
+
 	bool HeartbeatIsActive;
 
 private slots:
@@ -69,9 +72,6 @@ private:
 
 	uint64_t _lastBytesSent;
 	uint64_t _lastBytesSentTime;
-
-	void broadcastUpdate(const char* updateType,
-		obs_data_t* additionalFields);
 
 	void OnSceneChange();
 	void OnSceneListChange();

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -49,8 +49,7 @@ public:
 	const char* GetRecordingTimecode();
 	obs_data_t* GetStats();
 
-	void broadcastUpdate(const char* updateType,
-		obs_data_t* additionalFields);
+	void OnBroadcastCustomMessage(QString realm, OBSDataAutoRelease data);
 
 	bool HeartbeatIsActive;
 
@@ -72,6 +71,9 @@ private:
 
 	uint64_t _lastBytesSent;
 	uint64_t _lastBytesSentTime;
+
+	void broadcastUpdate(const char* updateType,
+		obs_data_t* additionalFields);
 
 	void OnSceneChange();
 	void OnSceneListChange();

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -49,7 +49,7 @@ public:
 	const char* GetRecordingTimecode();
 	obs_data_t* GetStats();
 
-	void OnBroadcastCustomMessage(QString realm, OBSDataAutoRelease data);
+	void OnBroadcastCustomMessage(QString realm, obs_data_t* data);
 
 	bool HeartbeatIsActive;
 

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -36,6 +36,8 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "SetFilenameFormatting", WSRequestHandler::HandleSetFilenameFormatting },
 	{ "GetFilenameFormatting", WSRequestHandler::HandleGetFilenameFormatting },
 
+	{ "BroadcastWebSocketMessage", WSRequestHandler::HandleBroadcastWebSocketMessage },
+
 	{ "SetCurrentScene", WSRequestHandler::HandleSetCurrentScene },
 	{ "GetCurrentScene", WSRequestHandler::HandleGetCurrentScene },
 	{ "GetSceneList", WSRequestHandler::HandleGetSceneList },

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -36,7 +36,7 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "SetFilenameFormatting", WSRequestHandler::HandleSetFilenameFormatting },
 	{ "GetFilenameFormatting", WSRequestHandler::HandleGetFilenameFormatting },
 
-	{ "BroadcastWebSocketMessage", WSRequestHandler::HandleBroadcastWebSocketMessage },
+	{ "BroadcastCustomMessage", WSRequestHandler::HandleBroadcastCustomMessage },
 
 	{ "SetCurrentScene", WSRequestHandler::HandleSetCurrentScene },
 	{ "GetCurrentScene", WSRequestHandler::HandleGetCurrentScene },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -74,6 +74,8 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleSetFilenameFormatting(WSRequestHandler* req);
 		static HandlerResponse HandleGetFilenameFormatting(WSRequestHandler* req);
 
+		static HandlerResponse HandleBroadcastWebSocketMessage(WSRequestHandler* req);
+
 		static HandlerResponse HandleSetCurrentScene(WSRequestHandler* req);
 		static HandlerResponse HandleGetCurrentScene(WSRequestHandler* req);
 		static HandlerResponse HandleGetSceneList(WSRequestHandler* req);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -74,7 +74,7 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleSetFilenameFormatting(WSRequestHandler* req);
 		static HandlerResponse HandleGetFilenameFormatting(WSRequestHandler* req);
 
-		static HandlerResponse HandleBroadcastWebSocketMessage(WSRequestHandler* req);
+		static HandlerResponse HandleBroadcastCustomMessage(WSRequestHandler* req);
 
 		static HandlerResponse HandleSetCurrentScene(WSRequestHandler* req);
 		static HandlerResponse HandleGetCurrentScene(WSRequestHandler* req);

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -232,6 +232,45 @@ HandlerResponse WSRequestHandler::HandleGetStats(WSRequestHandler* req) {
 }
 
 /**
+ * Broadcast some Data (String) to all connected Websocket-Clients
+ *
+ * @param {String} `realm` Some Identifier to be choosen by the client
+ * @param {String} `data` User-defined data String
+ *
+ * @api requests
+ * @name Authenticate
+ * @category general
+ * @since 0.3
+ */
+HandlerResponse WSRequestHandler::HandleBroadcastWebSocketMessage(WSRequestHandler* req) {
+	if (!req->hasField("realm") || !req->hasField("data")) {
+		return req->SendErrorResponse("missing request parameters");
+	}
+
+	QString realm = obs_data_get_string(req->data, "realm");
+	QString data = obs_data_get_string(req->data, "data");
+
+	if (realm.isEmpty()) {
+		return req->SendErrorResponse("realm not specified!");
+	}
+
+	if (data.isEmpty()) {
+		return req->SendErrorResponse("data not specified!");
+	}
+
+	auto events = GetEventsSystem();
+
+	OBSDataAutoRelease broadcastData = obs_data_create();
+	obs_data_set_string(broadcastData, "realm", realm.toUtf8().constData());
+	obs_data_set_string(broadcastData, "data", data.toUtf8().constData());
+
+	events->broadcastUpdate("BroadcastWebSocketMessage", broadcastData);
+
+	return req->SendOKResponse();
+}
+
+
+/**
  * Get basic OBS video information
  * 
  * @return {int} `baseWidth` Base (canvas) width

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -235,12 +235,12 @@ HandlerResponse WSRequestHandler::HandleGetStats(WSRequestHandler* req) {
  * Broadcast some Data (String) to all connected Websocket-Clients
  *
  * @param {String} `realm` Some Identifier to be choosen by the client
- * @param {String} `data` User-defined data String
+ * @param {Object} `data` User-defined data String
  *
- * @api requests
- * @name Authenticate
+ * @api general
+ * @name BroadcastWebSocketMessage
  * @category general
- * @since 0.3
+ * @since 4.7.0
  */
 HandlerResponse WSRequestHandler::HandleBroadcastWebSocketMessage(WSRequestHandler* req) {
 	if (!req->hasField("realm") || !req->hasField("data")) {
@@ -248,13 +248,13 @@ HandlerResponse WSRequestHandler::HandleBroadcastWebSocketMessage(WSRequestHandl
 	}
 
 	QString realm = obs_data_get_string(req->data, "realm");
-	QString data = obs_data_get_string(req->data, "data");
+	OBSDataAutoRelease data = obs_data_get_obj(req->data, "data");
 
 	if (realm.isEmpty()) {
 		return req->SendErrorResponse("realm not specified!");
 	}
 
-	if (data.isEmpty()) {
+	if (!data) {
 		return req->SendErrorResponse("data not specified!");
 	}
 
@@ -262,7 +262,7 @@ HandlerResponse WSRequestHandler::HandleBroadcastWebSocketMessage(WSRequestHandl
 
 	OBSDataAutoRelease broadcastData = obs_data_create();
 	obs_data_set_string(broadcastData, "realm", realm.toUtf8().constData());
-	obs_data_set_string(broadcastData, "data", data.toUtf8().constData());
+	obs_data_set_obj(broadcastData, "data", data);
 
 	events->broadcastUpdate("BroadcastWebSocketMessage", broadcastData);
 

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -232,7 +232,7 @@ HandlerResponse WSRequestHandler::HandleGetStats(WSRequestHandler* req) {
 }
 
 /**
- * Broadcast some Data (String) to all connected Websocket-Clients
+ * Broadcast some data to all connected WebSocket clients
  *
  * @param {String} `realm` Some Identifier to be choosen by the client
  * @param {Object} `data` User-defined data

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -259,12 +259,7 @@ HandlerResponse WSRequestHandler::HandleBroadcastCustomMessage(WSRequestHandler*
 	}
 
 	auto events = GetEventsSystem();
-
-	OBSDataAutoRelease broadcastData = obs_data_create();
-	obs_data_set_string(broadcastData, "realm", realm.toUtf8().constData());
-	obs_data_set_obj(broadcastData, "data", data);
-
-	events->broadcastUpdate("CustomMessage", broadcastData);
+	events->OnBroadcastCustomMessage(realm, data);
 
 	return req->SendOKResponse();
 }

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -235,7 +235,7 @@ HandlerResponse WSRequestHandler::HandleGetStats(WSRequestHandler* req) {
  * Broadcast some Data (String) to all connected Websocket-Clients
  *
  * @param {String} `realm` Some Identifier to be choosen by the client
- * @param {Object} `data` User-defined data String
+ * @param {Object} `data` User-defined data
  *
  * @api general
  * @name BroadcastWebSocketMessage

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -232,17 +232,17 @@ HandlerResponse WSRequestHandler::HandleGetStats(WSRequestHandler* req) {
 }
 
 /**
- * Broadcast some data to all connected WebSocket clients
+ * Broadcast custom message to all connected WebSocket clients
  *
- * @param {String} `realm` Some Identifier to be choosen by the client
+ * @param {String} `realm` Identifier to be choosen by the client
  * @param {Object} `data` User-defined data
  *
  * @api general
- * @name BroadcastWebSocketMessage
+ * @name BroadcastCustomMessage
  * @category general
  * @since 4.7.0
  */
-HandlerResponse WSRequestHandler::HandleBroadcastWebSocketMessage(WSRequestHandler* req) {
+HandlerResponse WSRequestHandler::HandleBroadcastCustomMessage(WSRequestHandler* req) {
 	if (!req->hasField("realm") || !req->hasField("data")) {
 		return req->SendErrorResponse("missing request parameters");
 	}
@@ -264,7 +264,7 @@ HandlerResponse WSRequestHandler::HandleBroadcastWebSocketMessage(WSRequestHandl
 	obs_data_set_string(broadcastData, "realm", realm.toUtf8().constData());
 	obs_data_set_obj(broadcastData, "data", data);
 
-	events->broadcastUpdate("BroadcastWebSocketMessage", broadcastData);
+	events->broadcastUpdate("CustomMessage", broadcastData);
 
 	return req->SendOKResponse();
 }


### PR DESCRIPTION
This PR adds a new function "BroadcastWebSocketMessage" which takes two parameters: realm and data. realm is intended to be a user-defined string to distinguish the source/recipient/scope of the message and data is the actual message.

Why?

With this change for example a javascript code in a browser source can connect to the websocket server and can receive such Messages and act upon them. This makes it possible for example to write some remote controlling software which triggers actions in a browser source without the need for any additional server.
