### PR TITLE
Expand GetSceneItems with a 'full' flag for more info

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -17,7 +17,9 @@
         "{Number} `x`",
         "{Number} `y`",
         "{String (optional)} `parentGroupName` Name of the item's parent (if this item belongs to a group)",
-        "{Array<SceneItem> (optional)} `groupChildren` List of children (if this item is a group)"
+        "{Array<SceneItem> (optional)} `groupChildren` List of children (if this item is a group)",
+        "{Boolean (optional)} `muted` Whether the source has been muted (only included if full info was requested)",
+        "{Number (optional)} `alignment` The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis. (Only included if full info was requested.)"
       ],
       "properties": [
         {
@@ -89,6 +91,16 @@
           "type": "Array<SceneItem> (optional)",
           "name": "groupChildren",
           "description": "List of children (if this item is a group)"
+        },
+        {
+          "type": "Boolean (optional)",
+          "name": "muted",
+          "description": "Whether the source has been muted (only included if full info was requested)"
+        },
+        {
+          "type": "Number (optional)",
+          "name": "alignment",
+          "description": "The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis. (Only included if full info was requested.)"
         }
       ],
       "typedefs": [
@@ -4980,6 +4992,7 @@
       {
         "subheads": [],
         "description": "Get the current scene's name and source items.",
+        "param": "{bool (optional)} `full` If true, extra information will be returned about each item",
         "return": [
           "{String} `name` Name of the currently active scene.",
           "{Array<SceneItem>} `sources` Ordered list of the current scene's source items."
@@ -4998,6 +5011,13 @@
             "type": "Array<SceneItem>",
             "name": "sources",
             "description": "Ordered list of the current scene's source items."
+          }
+        ],
+        "params": [
+          {
+            "type": "bool (optional)",
+            "name": "full",
+            "description": "If true, extra information will be returned about each item"
           }
         ],
         "names": [

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -234,6 +234,8 @@ These are complex types, such as `Source` and `Scene`, which are used as argumen
 | `y` | _Number_ |  |
 | `parentGroupName` | _String (optional)_ | Name of the item's parent (if this item belongs to a group) |
 | `groupChildren` | _Array&lt;SceneItem&gt; (optional)_ | List of children (if this item is a group) |
+| `muted` | _Boolean (optional)_ | Whether the source has been muted (only included if full info was requested) |
+| `alignment` | _Number (optional)_ | The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis. (Only included if full info was requested.) |
 ## SceneItemTransform
 | Name | Type  | Description |
 | ---- | :---: | ------------|
@@ -2044,7 +2046,10 @@ Get the current scene's name and source items.
 
 **Request Fields:**
 
-_No specified parameters._
+| Name | Type  | Description |
+| ---- | :---: | ------------|
+| `full` | _bool (optional)_ | If true, extra information will be returned about each item |
+
 
 **Response Items:**
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -37,8 +37,8 @@ typedef bool(*RecordingPausedFunction)();
 class Utils {
   public:
 	static obs_data_array_t* StringListToArray(char** strings, const char* key);
-	static obs_data_array_t* GetSceneItems(obs_source_t* source);
-	static obs_data_t* GetSceneItemData(obs_sceneitem_t* item);
+	static obs_data_array_t* GetSceneItems(obs_source_t* source, bool full=false);
+	static obs_data_t* GetSceneItemData(obs_sceneitem_t* item, bool full);
 
 	// These two functions support nested lookup into groups
 	static obs_sceneitem_t* GetSceneItemFromName(obs_scene_t* scene, QString name);

--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -37,6 +37,7 @@ HandlerResponse WSRequestHandler::HandleSetCurrentScene(WSRequestHandler* req) {
 /**
  * Get the current scene's name and source items.
  * 
+ * @param {bool (optional)} `full` If true, extra information will be returned about each item
  * @return {String} `name` Name of the currently active scene.
  * @return {Array<SceneItem>} `sources` Ordered list of the current scene's source items.
  *
@@ -47,7 +48,8 @@ HandlerResponse WSRequestHandler::HandleSetCurrentScene(WSRequestHandler* req) {
  */
 HandlerResponse WSRequestHandler::HandleGetCurrentScene(WSRequestHandler* req) {
 	OBSSourceAutoRelease currentScene = obs_frontend_get_current_scene();
-	OBSDataArrayAutoRelease sceneItems = Utils::GetSceneItems(currentScene);
+	bool full = obs_data_get_bool(req->data, "full");
+	OBSDataArrayAutoRelease sceneItems = Utils::GetSceneItems(currentScene, full);
 
 	OBSDataAutoRelease data = obs_data_create();
 	obs_data_set_string(data, "name", obs_source_get_name(currentScene));


### PR DESCRIPTION
As suggested in #324, it may be better to keep the events lightweight, but have a "more info pls" flag on the explicit GetSceneItems. This keeps the current paths fast and simple, but allows a one-round-trip request that will give additional information.

Currently, this additional information is a `muted` flag on audio sources, and the `alignment` (gravity) on visual ones.