### PR TITLE
allow for "linuxbrowser_source" to be controlled

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -923,7 +923,7 @@ HandlerResponse WSRequestHandler::HandleGetBrowserSourceProperties(WSRequestHand
 	}
 
 	QString sourceId = obs_source_get_id(source);
-	if (sourceId != "browser_source" && sourceId != "linuxbrowser_source") {
+	if (sourceId != "browser_source" && sourceId != "linuxbrowser-source") {
 		return req->SendErrorResponse("not a browser source");
 	}
 
@@ -969,7 +969,7 @@ HandlerResponse WSRequestHandler::HandleSetBrowserSourceProperties(WSRequestHand
 	}
 
 	QString sourceId = obs_source_get_id(source);
-	if(sourceId != "browser_source" && sourceId != "linuxbrowser_source") {
+	if(sourceId != "browser_source" && sourceId != "linuxbrowser-source") {
 		return req->SendErrorResponse("not a browser source");
 	}
 

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -923,7 +923,7 @@ HandlerResponse WSRequestHandler::HandleGetBrowserSourceProperties(WSRequestHand
 	}
 
 	QString sourceId = obs_source_get_id(source);
-	if (sourceId != "browser_source") {
+	if (sourceId != "browser_source" && sourceId != "linuxbrowser_source") {
 		return req->SendErrorResponse("not a browser source");
 	}
 
@@ -969,7 +969,7 @@ HandlerResponse WSRequestHandler::HandleSetBrowserSourceProperties(WSRequestHand
 	}
 
 	QString sourceId = obs_source_get_id(source);
-	if(sourceId != "browser_source") {
+	if(sourceId != "browser_source" && sourceId != "linuxbrowser_source") {
 		return req->SendErrorResponse("not a browser source");
 	}
 


### PR DESCRIPTION
based on the request at https://github.com/bazukas/obs-linuxbrowser/issues/46 I did a quick search for the string "browser_source" and these seem to be the only two occurrences. Enhancing the conditional with the identifier of the obs-linuxbrowser plugin, this should solve the problem.

As I'm currently not at home, I can't verify this does what it should, but I will test it later tonight.

@mjc666 if you are still interested please give it a test run to verify if these two plugins work together now.