### PR TITLE
Recording Pause support

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -31,6 +31,9 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-module.h>
 #include <util/config-file.h>
 
+typedef void(*PauseRecordingFunction)(bool);
+typedef bool(*RecordingPausedFunction)();
+
 class Utils {
   public:
 	static obs_data_array_t* StringListToArray(char** strings, const char* key);
@@ -78,4 +81,8 @@ class Utils {
 
 	static const char* GetFilenameFormatting();
 	static bool SetFilenameFormatting(const char* filenameFormatting);
+
+	static bool RecordingPauseSupported();
+	static bool RecordingPaused();
+	static void PauseRecording(bool pause);
 };

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -708,6 +708,7 @@ void WSEvents::OnExit() {
 void WSEvents::StreamStatus() {
 	bool streamingActive = obs_frontend_streaming_active();
 	bool recordingActive = obs_frontend_recording_active();
+	bool recordingPaused = obs_frontend_recording_paused();
 	bool replayBufferActive = obs_frontend_replay_buffer_active();
 
 	OBSOutputAutoRelease streamOutput = obs_frontend_get_streaming_output();
@@ -746,6 +747,7 @@ void WSEvents::StreamStatus() {
 
 	obs_data_set_bool(data, "streaming", streamingActive);
 	obs_data_set_bool(data, "recording", recordingActive);
+	obs_data_set_bool(data, "recording-paused", recordingPaused);
 	obs_data_set_bool(data, "replay-buffer-active", replayBufferActive);
 
 	obs_data_set_int(data, "bytes-per-sec", bytesPerSec);
@@ -792,6 +794,7 @@ void WSEvents::Heartbeat() {
 
 	bool streamingActive = obs_frontend_streaming_active();
 	bool recordingActive = obs_frontend_recording_active();
+	bool recordingPaused = obs_frontend_recording_paused();
 
 	OBSDataAutoRelease data = obs_data_create();
 	OBSOutputAutoRelease recordOutput = obs_frontend_get_recording_output();
@@ -814,6 +817,7 @@ void WSEvents::Heartbeat() {
 	}
 
 	obs_data_set_bool(data, "recording", recordingActive);
+	obs_data_set_bool(data, "recording-paused", recordingPaused);
 	if (recordingActive) {
 		uint64_t totalRecordTime = (os_gettime_ns() - _recStarttime) / 1000000000;
 		obs_data_set_int(data, "total-record-time", totalRecordTime);

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -770,9 +770,7 @@ void WSEvents::StreamStatus() {
 	_lastBytesSent = bytesSent;
 	_lastBytesSentTime = bytesSentTime;
 
-	uint64_t totalStreamTime =
-		(os_gettime_ns() - _streamStarttime) / 1000000000;
-
+	uint64_t totalStreamTime = (getStreamingTime() / 1000000000ULL);
 	int totalFrames = obs_output_get_total_frames(streamOutput);
 	int droppedFrames = obs_output_get_frames_dropped(streamOutput);
 
@@ -845,8 +843,7 @@ void WSEvents::Heartbeat() {
 
 	obs_data_set_bool(data, "streaming", streamingActive);
 	if (streamingActive) {
-		uint64_t totalStreamTime = (os_gettime_ns() - _streamStarttime) / 1000000000;
-		obs_data_set_int(data, "total-stream-time", totalStreamTime);
+		obs_data_set_int(data, "total-stream-time", (getStreamingTime() / 1000000000ULL));
 		obs_data_set_int(data, "total-stream-bytes", (uint64_t)obs_output_get_total_bytes(streamOutput));
 		obs_data_set_int(data, "total-stream-frames", obs_output_get_total_frames(streamOutput));
 	}

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -206,6 +206,14 @@ void WSEvents::FrontendEventHandler(enum obs_frontend_event event, void* private
 			owner->OnRecordingStopped();
 			break;
 
+		case OBS_FRONTEND_EVENT_RECORDING_PAUSED:
+			owner->OnRecordingPaused();
+			break;
+
+		case OBS_FRONTEND_EVENT_RECORDING_UNPAUSED:
+			owner->OnRecordingResumed();
+			break;
+
 		case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING:
 			owner->OnReplayStarting();
 			break;
@@ -615,6 +623,30 @@ void WSEvents::OnRecordingStopping() {
 void WSEvents::OnRecordingStopped() {
 	_recStarttime = 0;
 	broadcastUpdate("RecordingStopped");
+}
+
+/**
+ * Current recording paused
+ *
+ * @api events
+ * @name RecordingPaused
+ * @category recording
+ * @since 4.7.0
+ */
+void WSEvents::OnRecordingPaused() {
+	broadcastUpdate("RecordingPaused");
+}
+
+/**
+ * Current recording resumed
+ *
+ * @api events
+ * @name RecordingResumed
+ * @category recording
+ * @since 4.7.0
+ */
+void WSEvents::OnRecordingResumed() {
+	broadcastUpdate("RecordingResumed");
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -17,6 +17,7 @@
  * with this program. If not, see <https://www.gnu.org/licenses/>
  */
 
+#include <inttypes.h>
 #include <util/platform.h>
 
 #include <QtWidgets/QPushButton>
@@ -39,7 +40,7 @@ QString nsToTimestamp(uint64_t ns) {
 	uint64_t secsPart = secs % 60ULL;
 	uint64_t msPart = ms % 1000ULL;
 
-	return QString::asprintf("%02llu:%02llu:%02llu.%03llu", hoursPart, minutesPart, secsPart, msPart);
+	return QString::asprintf("%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64 ".%03" PRIu64, hoursPart, minutesPart, secsPart, msPart);
 }
 
 const char* sourceTypeToString(obs_source_type type) {

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -381,7 +381,7 @@ uint64_t WSEvents::getRecordingTime() {
 		return 0;
 	}
 
-	if (obs_frontend_recording_paused() && _recPauseTime > 0) {
+	if (Utils::RecordingPaused() && _recPauseTime > 0) {
 		return (_recPauseTime - _recStarttime);
 	}
 
@@ -746,7 +746,7 @@ void WSEvents::OnExit() {
 void WSEvents::StreamStatus() {
 	bool streamingActive = obs_frontend_streaming_active();
 	bool recordingActive = obs_frontend_recording_active();
-	bool recordingPaused = obs_frontend_recording_paused();
+	bool recordingPaused = Utils::RecordingPaused();
 	bool replayBufferActive = obs_frontend_replay_buffer_active();
 
 	OBSOutputAutoRelease streamOutput = obs_frontend_get_streaming_output();
@@ -832,7 +832,7 @@ void WSEvents::Heartbeat() {
 
 	bool streamingActive = obs_frontend_streaming_active();
 	bool recordingActive = obs_frontend_recording_active();
-	bool recordingPaused = obs_frontend_recording_paused();
+	bool recordingPaused = Utils::RecordingPaused();
 
 	OBSDataAutoRelease data = obs_data_create();
 	OBSOutputAutoRelease recordOutput = obs_frontend_get_recording_output();

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -74,6 +74,8 @@ WSEvents::WSEvents(WSServerPtr srv) :
 	_streamStarttime(0),
 	_recStarttime(0),
 	_recPauseTime(0),
+	_lastBytesSent(0),
+	_lastBytesSentTime(0),
 	HeartbeatIsActive(false),
 	pulse(false)
 {

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -43,10 +43,12 @@ public:
 	void hookTransitionBeginEvent();
 	void unhookTransitionBeginEvent();
 
-	uint64_t GetStreamingTime();
-	const char* GetStreamingTimecode();
-	uint64_t GetRecordingTime();
-	const char* GetRecordingTimecode();
+	uint64_t getStreamingTime();
+	uint64_t getRecordingTime();
+
+	QString getStreamingTimecode();
+	QString getRecordingTimecode();
+	
 	obs_data_t* GetStats();
 
 	void OnBroadcastCustomMessage(QString realm, obs_data_t* data);
@@ -68,6 +70,7 @@ private:
 
 	uint64_t _streamStarttime;
 	uint64_t _recStarttime;
+	uint64_t _recPauseTime;
 
 	uint64_t _lastBytesSent;
 	uint64_t _lastBytesSentTime;

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -69,8 +69,6 @@ private:
 	bool pulse;
 
 	uint64_t _streamStarttime;
-	uint64_t _recStarttime;
-	uint64_t _recPauseTime;
 
 	uint64_t _lastBytesSent;
 	uint64_t _lastBytesSentTime;

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -95,6 +95,8 @@ private:
 	void OnRecordingStarted();
 	void OnRecordingStopping();
 	void OnRecordingStopped();
+	void OnRecordingPaused();
+	void OnRecordingResumed();
 
 	void OnReplayStarting();
 	void OnReplayStarted();

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -24,7 +24,7 @@
 
 #include "WSRequestHandler.h"
 
-QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageMap {
+QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageMap{
 	{ "GetVersion", WSRequestHandler::HandleGetVersion },
 	{ "GetAuthRequired", WSRequestHandler::HandleGetAuthRequired },
 	{ "Authenticate", WSRequestHandler::HandleAuthenticate },
@@ -57,10 +57,14 @@ QHash<QString, HandlerResponse(*)(WSRequestHandler*)> WSRequestHandler::messageM
 	{ "GetStreamingStatus", WSRequestHandler::HandleGetStreamingStatus },
 	{ "StartStopStreaming", WSRequestHandler::HandleStartStopStreaming },
 	{ "StartStopRecording", WSRequestHandler::HandleStartStopRecording },
+
 	{ "StartStreaming", WSRequestHandler::HandleStartStreaming },
 	{ "StopStreaming", WSRequestHandler::HandleStopStreaming },
+
 	{ "StartRecording", WSRequestHandler::HandleStartRecording },
 	{ "StopRecording", WSRequestHandler::HandleStopRecording },
+	{ "PauseRecording", WSRequestHandler::HandlePauseRecording },
+	{ "ResumeRecording", WSRequestHandler::HandleResumeRecording },
 
 	{ "StartStopReplayBuffer", WSRequestHandler::HandleStartStopReplayBuffer },
 	{ "StartReplayBuffer", WSRequestHandler::HandleStartReplayBuffer },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -103,10 +103,14 @@ class WSRequestHandler : public QObject {
 		static HandlerResponse HandleGetStreamingStatus(WSRequestHandler* req);
 		static HandlerResponse HandleStartStopStreaming(WSRequestHandler* req);
 		static HandlerResponse HandleStartStopRecording(WSRequestHandler* req);
+
 		static HandlerResponse HandleStartStreaming(WSRequestHandler* req);
 		static HandlerResponse HandleStopStreaming(WSRequestHandler* req);
+
 		static HandlerResponse HandleStartRecording(WSRequestHandler* req);
 		static HandlerResponse HandleStopRecording(WSRequestHandler* req);
+		static HandlerResponse HandlePauseRecording(WSRequestHandler* req);
+		static HandlerResponse HandleResumeRecording(WSRequestHandler* req);
 
 		static HandlerResponse HandleStartStopReplayBuffer(WSRequestHandler* req);
 		static HandlerResponse HandleStartReplayBuffer(WSRequestHandler* req);

--- a/src/WSRequestHandler_Recording.cpp
+++ b/src/WSRequestHandler_Recording.cpp
@@ -56,13 +56,58 @@ HandlerResponse WSRequestHandler::HandleStartRecording(WSRequestHandler* req) {
 }
 
 /**
+* Pause the current recording.
+* Returns an error if recording is not active or already paused.
+*
+* @api requests
+* @name PauseRecording
+* @category recording
+* @since 4.7.0
+*/
+HandlerResponse WSRequestHandler::HandlePauseRecording(WSRequestHandler* req) {
+	if (!obs_frontend_recording_active()) {
+		return req->SendErrorResponse("recording is not active");
+	}
+
+	if (obs_frontend_recording_paused()) {
+		return req->SendErrorResponse("recording already paused");
+	}
+
+	obs_frontend_recording_pause(true);
+
+	return req->SendOKResponse();
+}
+
+/**
+* Resume/unpause the current recording (if paused).
+* Returns an error if recording is not active or not paused.
+*
+* @api requests
+* @name ResumeRecording
+* @category recording
+* @since 4.7.0
+*/
+HandlerResponse WSRequestHandler::HandleResumeRecording(WSRequestHandler* req) {
+	if (!obs_frontend_recording_active()) {
+		return req->SendErrorResponse("recording is not active");
+	}
+
+	if (!obs_frontend_recording_paused()) {
+		return req->SendErrorResponse("recording is not paused");
+	}
+
+	obs_frontend_recording_pause(false);
+
+	return req->SendOKResponse();
+}
+
+/**
  * In the current profile, sets the recording folder of the Simple and Advanced
  * output modes to the specified value.
  * 
  * Please note: if `SetRecordingFolder` is called while a recording is
  * in progress, the change won't be applied immediately and will be
  * effective on the next recording.
- * 
  * 
  * @param {String} `rec-folder` Path of the recording folder.
  *

--- a/src/WSRequestHandler_Recording.cpp
+++ b/src/WSRequestHandler_Recording.cpp
@@ -65,6 +65,10 @@ HandlerResponse WSRequestHandler::HandleStartRecording(WSRequestHandler* req) {
 * @since 4.7.0
 */
 HandlerResponse WSRequestHandler::HandlePauseRecording(WSRequestHandler* req) {
+	// TODO runtime check
+#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(23, 2, 2)
+	return req->SendErrorResponse("recording pause not supported");
+#else
 	if (!obs_frontend_recording_active()) {
 		return req->SendErrorResponse("recording is not active");
 	}
@@ -76,6 +80,7 @@ HandlerResponse WSRequestHandler::HandlePauseRecording(WSRequestHandler* req) {
 	obs_frontend_recording_pause(true);
 
 	return req->SendOKResponse();
+#endif
 }
 
 /**
@@ -88,6 +93,10 @@ HandlerResponse WSRequestHandler::HandlePauseRecording(WSRequestHandler* req) {
 * @since 4.7.0
 */
 HandlerResponse WSRequestHandler::HandleResumeRecording(WSRequestHandler* req) {
+	// TODO runtime check
+#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(23, 2, 2)
+	return req->SendErrorResponse("recording resume not supported");
+#else
 	if (!obs_frontend_recording_active()) {
 		return req->SendErrorResponse("recording is not active");
 	}
@@ -99,6 +108,7 @@ HandlerResponse WSRequestHandler::HandleResumeRecording(WSRequestHandler* req) {
 	obs_frontend_recording_pause(false);
 
 	return req->SendOKResponse();
+#endif
 }
 
 /**

--- a/src/WSRequestHandler_Recording.cpp
+++ b/src/WSRequestHandler_Recording.cpp
@@ -33,11 +33,7 @@ HandlerResponse ifCanPause(WSRequestHandler* req, std::function<HandlerResponse(
  * @since 0.3
  */
 HandlerResponse WSRequestHandler::HandleStartStopRecording(WSRequestHandler* req) {
-	if (obs_frontend_recording_active())
-		obs_frontend_recording_stop();
-	else
-		obs_frontend_recording_start();
-
+	(obs_frontend_recording_active() ? obs_frontend_recording_stop() : obs_frontend_recording_start());
 	return req->SendOKResponse();
 }
 
@@ -51,12 +47,12 @@ HandlerResponse WSRequestHandler::HandleStartStopRecording(WSRequestHandler* req
  * @since 4.1.0
  */
 HandlerResponse WSRequestHandler::HandleStartRecording(WSRequestHandler* req) {
-	if (obs_frontend_recording_active() == false) {
-		obs_frontend_recording_start();
-		return req->SendOKResponse();
-	} else {
+	if (obs_frontend_recording_active()) {
 		return req->SendErrorResponse("recording already active");
 	}
+
+	obs_frontend_recording_start();
+	return req->SendOKResponse();
 }
 
 /**
@@ -69,12 +65,12 @@ HandlerResponse WSRequestHandler::HandleStartRecording(WSRequestHandler* req) {
  * @since 4.1.0
  */
  HandlerResponse WSRequestHandler::HandleStopRecording(WSRequestHandler* req) {
-	if (obs_frontend_recording_active() == true) {
-		obs_frontend_recording_stop();
-		return req->SendOKResponse();
-	} else {
+	if (!obs_frontend_recording_active()) {
 		return req->SendErrorResponse("recording not active");
 	}
+
+	obs_frontend_recording_stop();
+	return req->SendOKResponse();
 }
 
 /**

--- a/src/WSRequestHandler_Recording.cpp
+++ b/src/WSRequestHandler_Recording.cpp
@@ -13,6 +13,8 @@ HandlerResponse ifCanPause(WSRequestHandler* req, std::function<HandlerResponse(
 	bool (*recordingPaused)() = (bool(*)())os_dlsym(frontendApi, "obs_frontend_recording_paused");
 	void (*pauseRecording)(bool) = (void(*)(bool))os_dlsym(frontendApi, "obs_frontend_recording_pause");
 
+	os_dlclose(frontendApi);
+
 	if (!recordingPaused || !pauseRecording) {
 		return req->SendErrorResponse("recording pause not supported");
 	}

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -29,17 +29,14 @@ HandlerResponse WSRequestHandler::HandleGetStreamingStatus(WSRequestHandler* req
 	obs_data_set_bool(data, "recording-paused", obs_frontend_recording_paused());
 	obs_data_set_bool(data, "preview-only", false);
 
-	const char* tc = nullptr;
 	if (obs_frontend_streaming_active()) {
-		tc = events->GetStreamingTimecode();
-		obs_data_set_string(data, "stream-timecode", tc);
-		bfree((void*)tc);
+		QString streamingTimecode = events->getStreamingTimecode();
+		obs_data_set_string(data, "stream-timecode", streamingTimecode.toUtf8().constData());
 	}
 
 	if (obs_frontend_recording_active()) {
-		tc = events->GetRecordingTimecode();
-		obs_data_set_string(data, "rec-timecode", tc);
-		bfree((void*)tc);
+		QString recordingTimecode = events->getRecordingTimecode();
+		obs_data_set_string(data, "rec-timecode", recordingTimecode.toUtf8().constData());
 	}
 
 	return req->SendOKResponse(data);

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -26,7 +26,7 @@ HandlerResponse WSRequestHandler::HandleGetStreamingStatus(WSRequestHandler* req
 	OBSDataAutoRelease data = obs_data_create();
 	obs_data_set_bool(data, "streaming", obs_frontend_streaming_active());
 	obs_data_set_bool(data, "recording", obs_frontend_recording_active());
-	obs_data_set_bool(data, "recording-paused", obs_frontend_recording_paused());
+	obs_data_set_bool(data, "recording-paused", Utils::RecordingPaused());
 	obs_data_set_bool(data, "preview-only", false);
 
 	if (obs_frontend_streaming_active()) {

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -26,6 +26,7 @@ HandlerResponse WSRequestHandler::HandleGetStreamingStatus(WSRequestHandler* req
 	OBSDataAutoRelease data = obs_data_create();
 	obs_data_set_bool(data, "streaming", obs_frontend_streaming_active());
 	obs_data_set_bool(data, "recording", obs_frontend_recording_active());
+	obs_data_set_bool(data, "recording-paused", obs_frontend_recording_paused());
 	obs_data_set_bool(data, "preview-only", false);
 
 	const char* tc = nullptr;


### PR DESCRIPTION
Changes & additions:
- [X] New request types: `PauseRecording` and `ResumeRecording`
- [x] Add a `recording-paused` property to the response of `GetStreamingStatus`
- [x] Add a `recording-paused` property in the body of the `Heartbeat` and `StreamStatus` events
- [x] Add `RecordingPaused` and `RecordingResumed` events
- [x] Fix computation of the recording timecode

Closes #370 