### PR TITLE
ci(macos): fix lookup path of Qt dependencies for new OBS bundle format

### DIFF
--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -24,8 +24,8 @@ export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 echo "[obs-websocket] Modifying obs-websocket.so"
 install_name_tool \
 	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
-	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
-	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
+	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui \
+	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore \
 	./build/obs-websocket.so
 
 # Check if replacement worked

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -23,9 +23,9 @@ export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
 echo "[obs-websocket] Modifying obs-websocket.so"
 install_name_tool \
-	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @rpath/QtWidgets \
-	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @rpath/QtGui \
-	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \
+	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
+	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
+	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
 	./build/obs-websocket.so
 
 # Check if replacement worked

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -23,9 +23,9 @@ export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
 echo "[obs-websocket] Modifying obs-websocket.so"
 install_name_tool \
-	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @rpath/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
-	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @rpath/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
-	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @rpath/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
+	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
+	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
+	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
 	./build/obs-websocket.so
 
 # Check if replacement worked

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -23,9 +23,12 @@ export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
 echo "[obs-websocket] Modifying obs-websocket.so"
 install_name_tool \
-	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
-	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui \
-	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore \
+	-add_rpath @executable_path/../Frameworks/QtWidgets.framework/Versions/5/ \
+	-add_rpath @executable_path/../Frameworks/QtGui.framework/Versions/5/ \
+	-add_rpath @executable_path/../Frameworks/QtCore.framework/Versions/5/ \
+	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @rpath/QtWidgets \
+	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @rpath/QtGui \
+	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \
 	./build/obs-websocket.so
 
 # Check if replacement worked

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -23,9 +23,9 @@ export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
 echo "[obs-websocket] Modifying obs-websocket.so"
 install_name_tool \
-	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
-	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
-	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
+	-change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @rpath/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
+	-change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @rpath/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
+	-change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @rpath/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
 	./build/obs-websocket.so
 
 # Check if replacement worked


### PR DESCRIPTION
To do :
- [x] Keep the current @rpath lookup as a fallback for older OBS versions