### PR TITLE
Switch from using caption_text1 to caption_text2

### DIFF
--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -307,7 +307,8 @@ HandlerResponse WSRequestHandler::HandleSendCaptions(WSRequestHandler* req) {
 	OBSOutputAutoRelease output = obs_frontend_get_streaming_output();
 	if (output) {
 		const char* caption = obs_data_get_string(req->data, "text");
-		obs_output_output_caption_text1(output, caption);
+		// Send caption text with immediately (0 second delay)
+		obs_output_output_caption_text2(output, caption, 0.0);
 	}
 
 	return req->SendOKResponse();


### PR DESCRIPTION
Bug: Current implementation of `HandleSendCaptions` uses `obs_output_output_caption_text1` to send caption text but `obs_output_output_caption_text1` has a hardcoded delay of 2 seconds before sending the captions text. 

Here the code:
```
void obs_output_output_caption_text1(obs_output_t *output, const char *text)
{
	if (!obs_output_valid(output, "obs_output_output_caption_text1"))
		return;
	obs_output_output_caption_text2(output, text, 2.0f);
}
```

This leads to the captions being out of sync with video and continues to get out of sync as subsequent calls to send captions will have to wait in a queue with the other delayed text.

To solve this issue, instead of using `obs_output_output_caption_text1` switch to using `obs_output_output_caption_text2` with a 0 second delay so captions are in sync with the video.