### PR TITLE
feat(events): add "type" field to TransitionBegin

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -877,6 +877,7 @@ void WSEvents::TransitionDurationChanged(int ms) {
  * A transition (other than "cut") has begun.
  *
  * @return {String} `name` Transition name.
+ * @return {String} `type` Transition type.
  * @return {int} `duration` Transition duration (in milliseconds).
  * @return {String} `from-scene` Source scene of the transition
  * @return {String} `to-scene` Destination scene of the transition
@@ -901,6 +902,7 @@ void WSEvents::OnTransitionBegin(void* param, calldata_t* data) {
 
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "name", obs_source_get_name(transition));
+	obs_data_set_string(fields, "type", obs_source_get_id(transition));
 	obs_data_set_int(fields, "duration", duration);
 
 	OBSSourceAutoRelease sourceScene = obs_transition_get_source(transition, OBS_TRANSITION_SOURCE_A);


### PR DESCRIPTION
This field reports the type of the transition (`obs_stinger_transition`, `fade_to_color_transition`, etc), which can be useful for code which needs to react differently depending on what type of transition is being played.

Of note is that OBS calls this an `id`, but I think that's kind of a misleading name. `type` seems like a more semantic name for this information to me, but I'm open to changing it if we want to stay consistent with the nomenclature that OBS itself uses.