### PR TITLE
fix(events): don't advertise a false duration for fixed transitions

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -387,6 +387,13 @@ int Utils::GetTransitionDuration(obs_source_t* transition) {
 		return 0;
 	}
 
+	if (obs_transition_fixed(transition)) {
+		// If this transition has a fixed duration (such as a Stinger),
+		// we don't currently have a way of retrieving that number.
+		// For now, return -1 to indicate that we don't know the actual duration.
+		return -1;
+	}
+
 	OBSSourceAutoRelease destinationScene = obs_transition_get_active_source(transition);
 	OBSDataAutoRelease destinationSettings = obs_source_get_private_settings(destinationScene);
 

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -878,7 +878,9 @@ void WSEvents::TransitionDurationChanged(int ms) {
  *
  * @return {String} `name` Transition name.
  * @return {String} `type` Transition type.
- * @return {int} `duration` Transition duration (in milliseconds).
+ * @return {int} `duration` Transition duration (in milliseconds). 
+ * Will be -1 for any transition with a fixed duration, 
+ * such as a Stinger, due to limitations of the OBS API.
  * @return {String} `from-scene` Source scene of the transition
  * @return {String} `to-scene` Destination scene of the transition
  *


### PR DESCRIPTION
Some transitions, such as Stingers, have a fixed duration. There is currently no way to retrieve this value from the API, and `obs-websocket` will currently return an incorrect value when one of these transitions begins.

For now, I think it is better to explicitly return -1, which is a better indicator that we have no idea what the real duration is, instead of a misleading number which users might think looks correct at first glance.

Related to #408 