### PR TITLE
Fix SetStreamSettings when switching type

### DIFF
--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -212,7 +212,7 @@ RpcResponse WSRequestHandler::SetStreamSettings(const RpcRequest& request) {
 	if (requestedType != nullptr && requestedType != serviceType) {
 		OBSDataAutoRelease hotkeys = obs_hotkeys_save_service(service);
 		service = obs_service_create(
-			STREAM_SERVICE_ID, requestedType.toUtf8(), requestSettings, hotkeys);
+			requestedType.toUtf8(), STREAM_SERVICE_ID, requestSettings, hotkeys);
 		obs_frontend_set_streaming_service(service);
 	} else {
 		// If type isn't changing, we should overlay the settings we got

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -137,13 +137,13 @@ RpcResponse WSRequestHandler::StartStreaming(const RpcRequest& request) {
 				obs_data_apply(updatedSettings, newSettings); //then apply the settings from the request should they exist
 
 				newService = obs_service_create(
-					STREAM_SERVICE_ID, newType.toUtf8(),
+					newType.toUtf8(), STREAM_SERVICE_ID,
 					updatedSettings, csHotkeys);
 			}
 			else {
 				// Service type changed: override service settings
 				newService = obs_service_create(
-					STREAM_SERVICE_ID, newType.toUtf8(),
+					newType.toUtf8(), STREAM_SERVICE_ID,
 					newSettings, csHotkeys);
 			}
 

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -241,7 +241,7 @@ RpcResponse WSRequestHandler::SetStreamSettings(const RpcRequest& request) {
 	const char* responseType = obs_service_get_type(responseService);
 
 	OBSDataAutoRelease response = obs_data_create();
-	obs_data_set_string(response, "type", responseType.toUtf8());
+	obs_data_set_string(response, "type", responseType);
 	obs_data_set_obj(response, "settings", serviceSettings);
 
 	return request.success(response);

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -236,7 +236,9 @@ RpcResponse WSRequestHandler::SetStreamSettings(const RpcRequest& request) {
 		obs_frontend_save_streaming_service();
 	}
 
-	OBSDataAutoRelease serviceSettings = obs_service_get_settings(service);
+	OBSService responseService = obs_frontend_get_streaming_service();
+	OBSDataAutoRelease serviceSettings = obs_service_get_settings(responseService);
+	const char* responseType = obs_service_get_type(responseService);
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "type", requestedType.toUtf8());

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -137,13 +137,13 @@ RpcResponse WSRequestHandler::StartStreaming(const RpcRequest& request) {
 				obs_data_apply(updatedSettings, newSettings); //then apply the settings from the request should they exist
 
 				newService = obs_service_create(
-					newType.toUtf8(), STREAM_SERVICE_ID,
+					STREAM_SERVICE_ID, newType.toUtf8(),
 					updatedSettings, csHotkeys);
 			}
 			else {
 				// Service type changed: override service settings
 				newService = obs_service_create(
-					newType.toUtf8(), STREAM_SERVICE_ID,
+					STREAM_SERVICE_ID, newType.toUtf8(),
 					newSettings, csHotkeys);
 			}
 

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -213,6 +213,7 @@ RpcResponse WSRequestHandler::SetStreamSettings(const RpcRequest& request) {
 		OBSDataAutoRelease hotkeys = obs_hotkeys_save_service(service);
 		service = obs_service_create(
 			STREAM_SERVICE_ID, requestedType.toUtf8(), requestSettings, hotkeys);
+		obs_frontend_set_streaming_service(service);
 	} else {
 		// If type isn't changing, we should overlay the settings we got
 		// to the existing settings. By doing so, you can send a request that

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -241,7 +241,7 @@ RpcResponse WSRequestHandler::SetStreamSettings(const RpcRequest& request) {
 	const char* responseType = obs_service_get_type(responseService);
 
 	OBSDataAutoRelease response = obs_data_create();
-	obs_data_set_string(response, "type", requestedType.toUtf8());
+	obs_data_set_string(response, "type", responseType.toUtf8());
 	obs_data_set_obj(response, "settings", serviceSettings);
 
 	return request.success(response);

--- a/src/WSRequestHandler_Streaming.cpp
+++ b/src/WSRequestHandler_Streaming.cpp
@@ -212,7 +212,7 @@ RpcResponse WSRequestHandler::SetStreamSettings(const RpcRequest& request) {
 	if (requestedType != nullptr && requestedType != serviceType) {
 		OBSDataAutoRelease hotkeys = obs_hotkeys_save_service(service);
 		service = obs_service_create(
-			requestedType.toUtf8(), STREAM_SERVICE_ID, requestSettings, hotkeys);
+			STREAM_SERVICE_ID, requestedType.toUtf8(), requestSettings, hotkeys);
 	} else {
 		// If type isn't changing, we should overlay the settings we got
 		// to the existing settings. By doing so, you can send a request that


### PR DESCRIPTION
This fixes #378 by applying the stream settings where currently it defines the service and responds with the data of that service object, but does not actually apply it. This also changes the behavior of the response to read the result of the change (as if you called getstreamsettings), which should mean that if the change was not successful, the response object should differ from the request object.