### PR TITLE
Add a 'muted' flag to GetSceneItems

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -6,9 +6,11 @@
       "property": [
         "{Number} `cy`",
         "{Number} `cx`",
+        "{Number} `alignment` The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis.",
         "{String} `name` The name of this Scene Item.",
         "{int} `id` Scene item ID",
         "{Boolean} `render` Whether or not this Scene Item is set to \"visible\".",
+        "{Boolean} `muted` Whether or not this Scene Item is muted.",
         "{Boolean} `locked` Whether or not this Scene Item is locked and can't be moved around",
         "{Number} `source_cx`",
         "{Number} `source_cy`",
@@ -31,6 +33,11 @@
           "description": ""
         },
         {
+          "type": "Number",
+          "name": "alignment",
+          "description": "The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis."
+        },
+        {
           "type": "String",
           "name": "name",
           "description": "The name of this Scene Item."
@@ -44,6 +51,11 @@
           "type": "Boolean",
           "name": "render",
           "description": "Whether or not this Scene Item is set to \"visible\"."
+        },
+        {
+          "type": "Boolean",
+          "name": "muted",
+          "description": "Whether or not this Scene Item is muted."
         },
         {
           "type": "Boolean",
@@ -3361,13 +3373,13 @@
         "param": [
           "{String (Optional)} `type` Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive).",
           "{int (Optional)} `monitor` Monitor to open the projector on. If -1 or omitted, opens a window.",
-          "{String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in base 64.",
+          "{String (Optional)} `geometry` Size and position of the projector window (only if monitor is -1). Encoded in Base64 using Qt's geometry encoding (https://doc.qt.io/qt-5/qwidget.html#saveGeometry). Corresponds to OBS's saved projectors.",
           "{String (Optional)} `name` Name of the source or scene to be displayed (ignored for other projector types)."
         ],
         "api": "requests",
         "name": "OpenProjector",
         "category": "general",
-        "since": "4.7.0",
+        "since": "unreleased",
         "params": [
           {
             "type": "String (Optional)",
@@ -3382,7 +3394,7 @@
           {
             "type": "String (Optional)",
             "name": "geometry",
-            "description": "Size and position of the projector window (only if monitor is -1). Encoded in base 64."
+            "description": "Size and position of the projector window (only if monitor is -1). Encoded in Base64 using Qt's geometry encoding (https://doc.qt.io/qt-5/qwidget.html#saveGeometry). Corresponds to OBS's saved projectors."
           },
           {
             "type": "String (Optional)",
@@ -3405,7 +3417,7 @@
         "sinces": [
           {
             "name": "",
-            "description": "4.7.0"
+            "description": "unreleased"
           }
         ],
         "heading": {
@@ -4253,6 +4265,7 @@
           "{int} `crop.bottom` The number of pixels cropped off the bottom of the source before scaling.",
           "{int} `crop.left` The number of pixels cropped off the left of the source before scaling.",
           "{bool} `visible` If the source is visible.",
+          "{bool} `muted` If the source is muted.",
           "{bool} `locked` If the source's transform is locked.",
           "{String} `bounds.type` Type of bounding box. Can be \"OBS_BOUNDS_STRETCH\", \"OBS_BOUNDS_SCALE_INNER\", \"OBS_BOUNDS_SCALE_OUTER\", \"OBS_BOUNDS_SCALE_TO_WIDTH\", \"OBS_BOUNDS_SCALE_TO_HEIGHT\", \"OBS_BOUNDS_MAX_ONLY\" or \"OBS_BOUNDS_NONE\".",
           "{int} `bounds.alignment` Alignment of the bounding box.",
@@ -4330,6 +4343,11 @@
             "type": "bool",
             "name": "visible",
             "description": "If the source is visible."
+          },
+          {
+            "type": "bool",
+            "name": "muted",
+            "description": "If the source is muted."
           },
           {
             "type": "bool",

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -224,9 +224,11 @@ These are complex types, such as `Source` and `Scene`, which are used as argumen
 | ---- | :---: | ------------|
 | `cy` | _Number_ |  |
 | `cx` | _Number_ |  |
+| `alignment` | _Number_ | The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis. |
 | `name` | _String_ | The name of this Scene Item. |
 | `id` | _int_ | Scene item ID |
 | `render` | _Boolean_ | Whether or not this Scene Item is set to "visible". |
+| `muted` | _Boolean_ | Whether or not this Scene Item is muted. |
 | `locked` | _Boolean_ | Whether or not this Scene Item is locked and can't be moved around |
 | `source_cx` | _Number_ |  |
 | `source_cy` | _Number_ |  |
@@ -1359,7 +1361,7 @@ _No specified parameters._
 ### OpenProjector
 
 
-- Added in v4.7.0
+- Unreleased
 
 Open a projector window or create a projector on a monitor. Requires OBS v24.0.4 or newer.
 
@@ -1369,7 +1371,7 @@ Open a projector window or create a projector on a monitor. Requires OBS v24.0.4
 | ---- | :---: | ------------|
 | `type` | _String (Optional)_ | Type of projector: Preview (default), Source, Scene, StudioProgram, or Multiview (case insensitive). |
 | `monitor` | _int (Optional)_ | Monitor to open the projector on. If -1 or omitted, opens a window. |
-| `geometry` | _String (Optional)_ | Size and position of the projector window (only if monitor is -1). Encoded in base 64. |
+| `geometry` | _String (Optional)_ | Size and position of the projector window (only if monitor is -1). Encoded in Base64 using Qt's geometry encoding (https://doc.qt.io/qt-5/qwidget.html#saveGeometry). Corresponds to OBS's saved projectors. |
 | `name` | _String (Optional)_ | Name of the source or scene to be displayed (ignored for other projector types). |
 
 
@@ -1835,6 +1837,7 @@ Coordinates are relative to the item's parent (the scene or group it belongs to)
 | `crop.bottom` | _int_ | The number of pixels cropped off the bottom of the source before scaling. |
 | `crop.left` | _int_ | The number of pixels cropped off the left of the source before scaling. |
 | `visible` | _bool_ | If the source is visible. |
+| `muted` | _bool_ | If the source is muted. |
 | `locked` | _bool_ | If the source's transform is locked. |
 | `bounds.type` | _String_ | Type of bounding box. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE". |
 | `bounds.alignment` | _int_ | Alignment of the bounding box. |

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -104,9 +104,11 @@ obs_data_array_t* Utils::GetSceneItems(obs_source_t* source) {
  * @typedef {Object} `SceneItem` An OBS Scene Item.
  * @property {Number} `cy`
  * @property {Number} `cx`
+ * @property {Number} `alignment` The point on the source that the item is manipulated from. The sum of 1=Left or 2=Right, and 4=Top or 8=Bottom, or omit to center on that axis.
  * @property {String} `name` The name of this Scene Item.
  * @property {int} `id` Scene item ID
  * @property {Boolean} `render` Whether or not this Scene Item is set to "visible".
+ * @property {Boolean} `muted` Whether or not this Scene Item is muted.
  * @property {Boolean} `locked` Whether or not this Scene Item is locked and can't be moved around
  * @property {Number} `source_cx`
  * @property {Number} `source_cy`

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -146,6 +146,7 @@ obs_data_t* Utils::GetSceneItemData(obs_sceneitem_t* item) {
 	obs_data_set_double(data, "y", pos.y);
 	obs_data_set_int(data, "source_cx", (int)item_width);
 	obs_data_set_int(data, "source_cy", (int)item_height);
+	obs_data_set_bool(data, "muted", obs_source_muted(itemSource));
 	obs_data_set_int(data, "alignment", (int)obs_sceneitem_get_alignment(item));
 	obs_data_set_double(data, "cx", item_width * scale.x);
 	obs_data_set_double(data, "cy", item_height * scale.y);

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -21,6 +21,7 @@
 * @return {int} `crop.bottom` The number of pixels cropped off the bottom of the source before scaling.
 * @return {int} `crop.left` The number of pixels cropped off the left of the source before scaling.
 * @return {bool} `visible` If the source is visible.
+* @return {bool} `muted` If the source is muted.
 * @return {bool} `locked` If the source's transform is locked.
 * @return {String} `bounds.type` Type of bounding box. Can be "OBS_BOUNDS_STRETCH", "OBS_BOUNDS_SCALE_INNER", "OBS_BOUNDS_SCALE_OUTER", "OBS_BOUNDS_SCALE_TO_WIDTH", "OBS_BOUNDS_SCALE_TO_HEIGHT", "OBS_BOUNDS_MAX_ONLY" or "OBS_BOUNDS_NONE".
 * @return {int} `bounds.alignment` Alignment of the bounding box.


### PR DESCRIPTION
Now that the alignment/gravity of visual scene items is being transmitted, the only part of #356 still remaining is to add a 'muted' flag to aural scene items. This allows a client to easily see which entities are currently muted when querying with GetSceneItems or seeing the full scene details in SwitchScenes; the status can already be updated by the SourceMuteStateChanged event.

Replaces PR #356.