### PR TITLE
Source Settings Validation

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -860,6 +860,11 @@ QString Utils::nsToTimestamp(uint64_t ns)
 	return QString::asprintf("%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64 ".%03" PRIu64, hoursPart, minutesPart, secsPart, msPart);
 }
 
+/**
+ * @typedef {Object} `PropertiesValidationError`
+ * @property {String} `field` Settings field targeted by this error
+ * @property {String} `message` Error message
+ */
 obs_data_array_t* Utils::validateSourceSettings(obs_properties_t* properties, obs_data_t* settings)
 {
 	obs_data_array_t* validationErrors = obs_data_array_create();

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -859,3 +859,35 @@ QString Utils::nsToTimestamp(uint64_t ns)
 
 	return QString::asprintf("%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64 ".%03" PRIu64, hoursPart, minutesPart, secsPart, msPart);
 }
+
+obs_data_array_t* Utils::validateSourceSettings(obs_properties_t* properties, obs_data_t* settings)
+{
+	obs_data_array_t* validationErrors = obs_data_array_create();
+	// TODO
+	return validationErrors;
+}
+
+bool Utils::applySourceSettings(obs_source_t* source, obs_data_t* sourceSettings, obs_data_array_t** outValidationErrors)
+{
+	obs_properties_t* sourceProperties = obs_source_properties(source);
+
+	obs_data_array_t* validationErrors = validateSourceSettings(sourceProperties, sourceSettings);
+	if (obs_data_array_count(validationErrors) > 0) {
+		if (outValidationErrors) {
+			outValidationErrors = &validationErrors;
+		} else {
+			obs_data_array_release(validationErrors);
+		}
+
+		return false;
+	}
+
+	// update settings
+	obs_source_update(source, sourceSettings);
+
+	// trigger update signal
+	obs_source_update_properties(source);
+
+	return true;
+}
+

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -85,4 +85,7 @@ namespace Utils {
 	bool SetFilenameFormatting(const char* filenameFormatting);
 
 	QString nsToTimestamp(uint64_t ns);
+
+	obs_data_array_t* validateSourceSettings(obs_properties_t* properties, obs_data_t* settings);
+	bool applySourceSettings(obs_source_t* source, obs_data_t* sourceSettings, obs_data_array_t** outValidationErrors = nullptr);
 };

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -484,8 +484,7 @@ RpcResponse WSRequestHandler::SetSourceSettings(const RpcRequest& request)
 	obs_data_apply(sourceSettings, currentSettings);
 	obs_data_apply(sourceSettings, newSettings);
 
-	obs_source_update(source, sourceSettings);
-	obs_source_update_properties(source);
+	Utils::applySourceSettings(source, sourceSettings);
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
@@ -733,7 +732,7 @@ RpcResponse WSRequestHandler::SetTextGDIPlusProperties(const RpcRequest& request
 		obs_data_set_bool(settings, "vertical", obs_data_get_bool(request.parameters(), "vertical"));
 	}
 
-	obs_source_update(source, settings);
+	Utils::applySourceSettings(source, settings);
 
 	return request.success();
 }
@@ -895,7 +894,7 @@ RpcResponse WSRequestHandler::SetTextFreetype2Properties(const RpcRequest& reque
 		obs_data_set_bool(settings, "word_wrap", obs_data_get_bool(request.parameters(), "word_wrap"));
 	}
 
-	obs_source_update(source, settings);
+	Utils::applySourceSettings(source, settings);
 
 	return request.success();
 }
@@ -1021,7 +1020,7 @@ RpcResponse WSRequestHandler::SetBrowserSourceProperties(const RpcRequest& reque
 		obs_data_set_int(settings, "fps", obs_data_get_int(request.parameters(), "fps"));
 	}
 
-	obs_source_update(source, settings);
+	Utils::applySourceSettings(source, settings);
 
 	return request.success();
 }
@@ -1383,7 +1382,8 @@ RpcResponse WSRequestHandler::SetSourceFilterSettings(const RpcRequest& request)
 
 	OBSDataAutoRelease settings = obs_source_get_settings(filter);
 	obs_data_apply(settings, newFilterSettings);
-	obs_source_update(filter, settings);
+
+	Utils::applySourceSettings(filter, settings);
 
 	return request.success();
 }

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -450,6 +450,7 @@ RpcResponse WSRequestHandler::GetSourceSettings(const RpcRequest& request)
 * @return {String} `sourceName` Source name
 * @return {String} `sourceType` Type of the specified source
 * @return {Object} `sourceSettings` Updated source settings
+* @return {Array<PropertiesValidationError> (optional)} `validationErrors` Returned alongside error messages if source settings validation fails
 *
 * @api requests
 * @name SetSourceSettings
@@ -484,16 +485,20 @@ RpcResponse WSRequestHandler::SetSourceSettings(const RpcRequest& request)
 	obs_data_apply(sourceSettings, currentSettings);
 	obs_data_apply(sourceSettings, newSettings);
 
-	bool success = Utils::applySourceSettings(source, sourceSettings);
-	if (!success) {
-		return request.failed("settings update failed");
-	}
-
 	OBSDataAutoRelease response = obs_data_create();
+
+	obs_data_array_t* inValidationErrors = nullptr;
+	bool success = Utils::applySourceSettings(source, sourceSettings, &inValidationErrors);
+	if (!success) {
+		OBSDataArrayAutoRelease validationErrors = inValidationErrors;
+
+		obs_data_set_array(response, "validationErrors", validationErrors);
+		return request.failed("settings update failed", response);
+	}
+	
 	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(response, "sourceType", obs_source_get_id(source));
 	obs_data_set_obj(response, "sourceSettings", sourceSettings);
-
 	return request.success(response);
 }
 
@@ -591,6 +596,8 @@ RpcResponse WSRequestHandler::GetTextGDIPlusProperties(const RpcRequest& request
  * @param {String (optional)} `valign` Text vertical alignment ("top", "center", "bottom").
  * @param {boolean (optional)} `vertical` Vertical text enabled.
  * @param {boolean (optional)} `render` Visibility of the scene item.
+ *
+ * @return {Array<PropertiesValidationError> (optional)} `validationErrors` Returned alongside error messages if source settings validation fails
  *
  * @api requests
  * @name SetTextGDIPlusProperties
@@ -735,9 +742,14 @@ RpcResponse WSRequestHandler::SetTextGDIPlusProperties(const RpcRequest& request
 		obs_data_set_bool(settings, "vertical", obs_data_get_bool(request.parameters(), "vertical"));
 	}
 
-	bool success = Utils::applySourceSettings(source, settings);
+	obs_data_array_t* inValidationErrors = nullptr;
+	bool success = Utils::applySourceSettings(source, settings, &inValidationErrors);
 	if (!success) {
-		return request.failed("settings update failed");
+		OBSDataArrayAutoRelease validationErrors = inValidationErrors;
+
+		OBSDataAutoRelease response = obs_data_create();
+		obs_data_set_array(response, "validationErrors", validationErrors);
+		return request.failed("settings update failed", response);
 	}
 
 	return request.success();
@@ -812,6 +824,8 @@ RpcResponse WSRequestHandler::GetTextFreetype2Properties(const RpcRequest& reque
  * @param {String (optional)} `text` Text content to be displayed.
  * @param {String (optional)} `text_file` File path.
  * @param {boolean (optional)} `word_wrap` Word wrap.
+ *
+ * @return {Array<PropertiesValidationError> (optional)} `validationErrors` Returned alongside error messages if source settings validation fails
  *
  * @api requests
  * @name SetTextFreetype2Properties
@@ -900,9 +914,14 @@ RpcResponse WSRequestHandler::SetTextFreetype2Properties(const RpcRequest& reque
 		obs_data_set_bool(settings, "word_wrap", obs_data_get_bool(request.parameters(), "word_wrap"));
 	}
 
-	bool success = Utils::applySourceSettings(source, settings);
+	obs_data_array_t* inValidationErrors = nullptr;
+	bool success = Utils::applySourceSettings(source, settings, &inValidationErrors);
 	if (!success) {
-		return request.failed("settings update failed");
+		OBSDataArrayAutoRelease validationErrors = inValidationErrors;
+
+		OBSDataAutoRelease response = obs_data_create();
+		obs_data_set_array(response, "validationErrors", validationErrors);
+		return request.failed("settings update failed", response);
 	}
 
 	return request.success();
@@ -964,6 +983,8 @@ RpcResponse WSRequestHandler::GetBrowserSourceProperties(const RpcRequest& reque
  * @param {int (optional)} `fps` Framerate.
  * @param {boolean (optional)} `shutdown` Indicates whether the source should be shutdown when not visible.
  * @param {boolean (optional)} `render` Visibility of the scene item.
+ *
+ * @return {Array<PropertiesValidationError> (optional)} `validationErrors` Returned alongside error messages if source settings validation fails
  *
  * @api requests
  * @name SetBrowserSourceProperties
@@ -1029,9 +1050,14 @@ RpcResponse WSRequestHandler::SetBrowserSourceProperties(const RpcRequest& reque
 		obs_data_set_int(settings, "fps", obs_data_get_int(request.parameters(), "fps"));
 	}
 
-	bool success = Utils::applySourceSettings(source, settings);
+	obs_data_array_t* inValidationErrors = nullptr;
+	bool success = Utils::applySourceSettings(source, settings, &inValidationErrors);
 	if (!success) {
-		return request.failed("settings update failed");
+		OBSDataArrayAutoRelease validationErrors = inValidationErrors;
+
+		OBSDataAutoRelease response = obs_data_create();
+		obs_data_set_array(response, "validationErrors", validationErrors);
+		return request.failed("settings update failed", response);
 	}
 
 	return request.success();
@@ -1367,6 +1393,8 @@ RpcResponse WSRequestHandler::MoveSourceFilter(const RpcRequest& request)
 * @param {String} `filterName` Name of the filter to reconfigure
 * @param {Object} `filterSettings` New settings. These will be merged to the current filter settings.
 *
+* @return {Array<PropertiesValidationError> (optional)} `validationErrors` Returned alongside error messages if source settings validation fails
+*
 * @api requests
 * @name SetSourceFilterSettings
 * @category sources
@@ -1395,9 +1423,14 @@ RpcResponse WSRequestHandler::SetSourceFilterSettings(const RpcRequest& request)
 	OBSDataAutoRelease settings = obs_source_get_settings(filter);
 	obs_data_apply(settings, newFilterSettings);
 
-	bool success = Utils::applySourceSettings(filter, settings);
+	obs_data_array_t* inValidationErrors = nullptr;
+	bool success = Utils::applySourceSettings(filter, settings, &inValidationErrors);
 	if (!success) {
-		return request.failed("settings update failed");
+		OBSDataArrayAutoRelease validationErrors = inValidationErrors;
+
+		OBSDataAutoRelease response = obs_data_create();
+		obs_data_set_array(response, "validationErrors", validationErrors);
+		return request.failed("settings update failed", response);
 	}
 
 	return request.success();

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -484,7 +484,10 @@ RpcResponse WSRequestHandler::SetSourceSettings(const RpcRequest& request)
 	obs_data_apply(sourceSettings, currentSettings);
 	obs_data_apply(sourceSettings, newSettings);
 
-	Utils::applySourceSettings(source, sourceSettings);
+	bool success = Utils::applySourceSettings(source, sourceSettings);
+	if (!success) {
+		return request.failed("settings update failed");
+	}
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
@@ -732,7 +735,10 @@ RpcResponse WSRequestHandler::SetTextGDIPlusProperties(const RpcRequest& request
 		obs_data_set_bool(settings, "vertical", obs_data_get_bool(request.parameters(), "vertical"));
 	}
 
-	Utils::applySourceSettings(source, settings);
+	bool success = Utils::applySourceSettings(source, settings);
+	if (!success) {
+		return request.failed("settings update failed");
+	}
 
 	return request.success();
 }
@@ -894,7 +900,10 @@ RpcResponse WSRequestHandler::SetTextFreetype2Properties(const RpcRequest& reque
 		obs_data_set_bool(settings, "word_wrap", obs_data_get_bool(request.parameters(), "word_wrap"));
 	}
 
-	Utils::applySourceSettings(source, settings);
+	bool success = Utils::applySourceSettings(source, settings);
+	if (!success) {
+		return request.failed("settings update failed");
+	}
 
 	return request.success();
 }
@@ -1020,7 +1029,10 @@ RpcResponse WSRequestHandler::SetBrowserSourceProperties(const RpcRequest& reque
 		obs_data_set_int(settings, "fps", obs_data_get_int(request.parameters(), "fps"));
 	}
 
-	Utils::applySourceSettings(source, settings);
+	bool success = Utils::applySourceSettings(source, settings);
+	if (!success) {
+		return request.failed("settings update failed");
+	}
 
 	return request.success();
 }
@@ -1383,7 +1395,10 @@ RpcResponse WSRequestHandler::SetSourceFilterSettings(const RpcRequest& request)
 	OBSDataAutoRelease settings = obs_source_get_settings(filter);
 	obs_data_apply(settings, newFilterSettings);
 
-	Utils::applySourceSettings(filter, settings);
+	bool success = Utils::applySourceSettings(filter, settings);
+	if (!success) {
+		return request.failed("settings update failed");
+	}
 
 	return request.success();
 }


### PR DESCRIPTION
Make sure that requests setting parameters on sources (inputs, filters, ...) get their parameters validated against what the target source properties spec allows.

Fixes #451 