### PR TITLE
[Docs] Fix link to GetCurrentScene

### DIFF
--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -2176,7 +2176,7 @@ _No specified parameters._
 | Name | Type  | Description |
 | ---- | :---: | ------------|
 | `current-scene` | _String_ | Name of the currently active scene. |
-| `scenes` | _Array&lt;Scene&gt;_ | Ordered list of the current profile's scenes (See `[GetCurrentScene](#getcurrentscene)` for more information). |
+| `scenes` | _Array&lt;Scene&gt;_ | Ordered list of the current profile's scenes (See [GetCurrentScene](#getcurrentscene) for more information). |
 
 
 ---

--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -60,7 +60,7 @@ RpcResponse WSRequestHandler::GetCurrentScene(const RpcRequest& request) {
  * Get a list of scenes in the currently active profile.
  * 
  * @return {String} `current-scene` Name of the currently active scene.
- * @return {Array<Scene>} `scenes` Ordered list of the current profile's scenes (See `[GetCurrentScene](#getcurrentscene)` for more information).
+ * @return {Array<Scene>} `scenes` Ordered list of the current profile's scenes (See [GetCurrentScene](#getcurrentscene) for more information).
  *
  * @api requests
  * @name GetSceneList


### PR DESCRIPTION
For some reason the link to the `GetCurrentScene` section of the docs was put into a codeblock