### PR TITLE
CI: Add Github Actions workflow for PRs and pushes to main branch

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -1,0 +1,412 @@
+name: 'CI Multiplatform Build'
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+    branches:
+      - 4.x-current
+  pull_request:
+    paths-ignore:
+      - '**.md'
+    branches:
+      - 4.x-current
+
+jobs:
+  windows:
+    name: 'Windows 32+64bit'
+    runs-on: [windows-latest]
+    if: contains(github.event.head_commit.message, '[skip ci]') != true
+    env:
+      QT_VERSION: '5.10.1'
+      WINDOWS_DEPS_VERSION: '2017'
+      CMAKE_GENERATOR: "Visual Studio 16 2019"
+      CMAKE_SYSTEM_VERSION: "10.0"
+    steps:
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.0
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/obs-websocket
+          submodules: 'recursive'
+      - name: 'Checkout OBS'
+        uses: actions/checkout@v2
+        with:
+          repository: obsproject/obs-studio
+          path: ${{ github.workspace }}/obs-studio
+          submodules: 'recursive'
+      - name: 'Get OBS-Studio git info'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=OBS_GIT_BRANCH::$(git rev-parse --abbrev-ref HEAD)
+          echo ::set-env name=OBS_GIT_HASH::$(git rev-parse --short HEAD)
+          echo ::set-env name=OBS_GIT_TAG::$(git describe --tags --abbrev=0)
+      - name: 'Checkout last OBS-Studio release (${{ env.OBS_GIT_TAG }})'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          git checkout ${{ env.OBS_GIT_TAG }}
+          git submodule update
+      - name: 'Get obs-websocket git info'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=GIT_BRANCH::${{ github.event.pull_request.head.ref }}
+          echo ::set-env name=GIT_HASH::$(git rev-parse --short HEAD)
+          echo ::set-env name=GIT_TAG::$(git describe --tags --abbrev=0)
+      - name: 'Install prerequisite: QT'
+        run: |
+          curl -kLO https://cdn-fastly.obsproject.com/downloads/Qt_${{ env.QT_VERSION }}.7z -f --retry 5 -C -
+          7z x Qt_${{ env.QT_VERSION }}.7z -o"${{ github.workspace }}\cmbuild\QT"
+      - name: 'Install prerequisite: Pre-built OBS dependencies'
+        run: |
+          curl -kLO https://cdn-fastly.obsproject.com/downloads/dependencies${{ env.WINDOWS_DEPS_VERSION }}.zip -f --retry 5 -C -
+          7z x dependencies${{ env.WINDOWS_DEPS_VERSION }}.zip -o"${{ github.workspace }}\cmbuild\deps"
+      - name: 'Restore OBS 32-bit build v${{ env.OBS_GIT_TAG }} from cache'
+        id: build-cache-obs-32
+        uses: actions/cache@v1
+        env:
+          CACHE_NAME: 'build-cache-obs-32'
+        with:
+          path: ${{ github.workspace }}/obs-studio/build32
+          key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.OBS_GIT_TAG }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_NAME }}-
+      - name: 'Configure OBS 32-bit'
+        if: steps.build-cache-obs-32.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          mkdir .\build32
+          cd .\build32
+          cmake -G "${{ env.CMAKE_GENERATOR }}" -A Win32 -DCMAKE_SYSTEM_VERSION="${{ env.CMAKE_SYSTEM_VERSION }}" -DQTDIR="${{ github.workspace }}\cmbuild\QT\${{ env.QT_VERSION }}\msvc2017" -DDepsPath="${{ github.workspace }}\cmbuild\deps\win32" -DBUILD_CAPTIONS=YES -DCOPIED_DEPENDENCIES=NO -DCOPY_DEPENDENCIES=YES ..
+      - name: 'Build OBS-Studio 32-bit'
+        if: steps.build-cache-obs-32.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          msbuild /m /p:Configuration=RelWithDebInfo .\build32\libobs\libobs.vcxproj
+          msbuild /m /p:Configuration=RelWithDebInfo .\build32\UI\obs-frontend-api\obs-frontend-api.vcxproj
+      - name: 'Restore OBS 64-bit build v${{ env.OBS_GIT_TAG }} from cache'
+        id: build-cache-obs-64
+        uses: actions/cache@v1
+        env:
+          CACHE_NAME: 'build-cache-obs-64'
+        with:
+          path: ${{ github.workspace }}/obs-studio/build64
+          key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ env.OBS_GIT_TAG }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_NAME }}-
+      - name: 'Configure OBS 64-bit'
+        if: steps.build-cache-obs-64.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          mkdir .\build64
+          cd .\build64
+          cmake -G "${{ env.CMAKE_GENERATOR }}" -A x64 -DCMAKE_SYSTEM_VERSION="${{ env.CMAKE_SYSTEM_VERSION }}" -DQTDIR="${{ github.workspace }}\cmbuild\QT\${{ env.QT_VERSION }}\msvc2017_64" -DDepsPath="${{ github.workspace }}\cmbuild\deps\win64" -DBUILD_CAPTIONS=YES -DCOPIED_DEPENDENCIES=NO -DCOPY_DEPENDENCIES=YES ..
+      - name: 'Build OBS-Studio 64-bit'
+        if: steps.build-cache-obs-64.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          msbuild /m /p:Configuration=RelWithDebInfo .\build64\libobs\libobs.vcxproj
+          msbuild /m /p:Configuration=RelWithDebInfo .\build64\UI\obs-frontend-api\obs-frontend-api.vcxproj
+      - name: 'Configure obs-websocket 64-bit'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: |
+          mkdir .\build64
+          cd .\build64
+          cmake -G "${{ env.CMAKE_GENERATOR }}" -A x64 -DCMAKE_SYSTEM_VERSION="${{ env.CMAKE_SYSTEM_VERSION }}" -DQTDIR="${{ github.workspace }}\cmbuild\QT\${{ env.QT_VERSION }}\msvc2017_64" -DLibObs_DIR="${{ github.workspace }}\obs-studio\build64\libobs" -DLIBOBS_INCLUDE_DIR="${{ github.workspace }}\obs-studio\libobs" -DLIBOBS_LIB="${{ github.workspace }}\obs-studio\build64\libobs\RelWithDebInfo\obs.lib" -DOBS_FRONTEND_LIB="${{ github.workspace }}\obs-studio\build64\UI\obs-frontend-api\RelWithDebInfo\obs-frontend-api.lib" ..
+      - name: 'Configure obs-websocket 32-bit'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: |
+          mkdir .\build32
+          cd .\build32
+          cmake -G "${{ env.CMAKE_GENERATOR }}" -A Win32 -DCMAKE_SYSTEM_VERSION="${{ env.CMAKE_SYSTEM_VERSION }}" -DQTDIR="${{ github.workspace }}\cmbuild\QT\${{ env.QT_VERSION }}\msvc2017" -DLibObs_DIR="${{ github.workspace }}\obs-studio\build32\libobs" -DLIBOBS_INCLUDE_DIR="${{ github.workspace }}\obs-studio\libobs" -DLIBOBS_LIB="${{ github.workspace }}\obs-studio\build32\libobs\RelWithDebInfo\obs.lib" -DOBS_FRONTEND_LIB="${{ github.workspace }}\obs-studio\build32\UI\obs-frontend-api\RelWithDebInfo\obs-frontend-api.lib" ..
+      - name: 'Build obs-websocket 64-bit'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: msbuild /m /p:Configuration=RelWithDebInfo .\build64\obs-websocket.sln
+      - name: 'Build obs-websocket 32-bit'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: msbuild /m /p:Configuration=RelWithDebInfo .\build32\obs-websocket.sln
+      - name: 'Set PR artifact filename'
+        shell: bash
+        run: |
+          FILENAME="obs-websocket-${{ env.GIT_HASH }}-Windows"
+          echo "::set-env name=FILENAME::$FILENAME"
+      - name: 'Package obs-websocket'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: |
+          mkdir package
+          cd package
+          7z a "${{ env.WIN_FILENAME }}.zip"  "..\release\*"
+          iscc ..\installer\installer.iss /O. /F"${{ env.WIN_FILENAME }}-Installer"
+      - name: 'Publish ${{ env.WIN_FILENAME }}.zip'
+        if: success()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: '${{ env.GIT_HASH }}-Windows'
+          path: ${{ github.workspace }}/obs-websocket/package/*.zip
+      - name: 'Publish ${{ env.WIN_FILENAME }}-Installer.exe'
+        if: success()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: '${{ env.GIT_HASH }}-Windows-Installer'
+          path: ${{ github.workspace }}/obs-websocket/package/*.exe
+  ubuntu64:
+    name: "Linux/Ubuntu 64-bit"
+    runs-on: [ubuntu-latest]
+    if: contains(github.event.head_commit.message, '[skip ci]') != true
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/obs-websocket
+          submodules: 'recursive'
+      - name: 'Checkout OBS'
+        uses: actions/checkout@v2
+        with:
+          repository: obsproject/obs-studio
+          path: ${{ github.workspace }}/obs-studio
+          submodules: 'recursive'
+      - name: 'Get OBS-Studio git info'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=OBS_GIT_BRANCH::$(git rev-parse --abbrev-ref HEAD)
+          echo ::set-env name=OBS_GIT_HASH::$(git rev-parse --short HEAD)
+          echo ::set-env name=OBS_GIT_TAG::$(git describe --tags --abbrev=0)
+      - name: 'Checkout last OBS-Studio release (${{ env.OBS_GIT_TAG }})'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          git checkout ${{ env.OBS_GIT_TAG }}
+          git submodule update
+      - name: 'Get obs-websocket git info'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=GIT_BRANCH::${{ github.event.pull_request.head.ref }}
+          echo ::set-env name=GIT_HASH::$(git rev-parse --short HEAD)
+          echo ::set-env name=GIT_TAG::$(git describe --tags --abbrev=0)
+      - name: 'Install prerequisites (Apt)'
+        shell: bash
+        run: |
+          sudo dpkg --add-architecture amd64
+          sudo apt-get -qq update
+          sudo apt-get install -y \
+           build-essential \
+           checkinstall \
+           cmake \
+           libasound2-dev \
+           libavcodec-dev \
+           libavdevice-dev \
+           libavfilter-dev \
+           libavformat-dev \
+           libavutil-dev \
+           libcurl4-openssl-dev \
+           libfdk-aac-dev \
+           libfontconfig-dev \
+           libfreetype6-dev \
+           libgl1-mesa-dev \
+           libjack-jackd2-dev \
+           libjansson-dev \
+           libluajit-5.1-dev \
+           libpulse-dev \
+           libqt5x11extras5-dev \
+           libspeexdsp-dev \
+           libswresample-dev \
+           libswscale-dev \
+           libudev-dev \
+           libv4l-dev \
+           libva-dev \
+           libvlc-dev \
+           libx11-dev \
+           libx264-dev \
+           libxcb-randr0-dev \
+           libxcb-shm0-dev \
+           libxcb-xinerama0-dev \
+           libxcomposite-dev \
+           libxinerama-dev \
+           libmbedtls-dev \
+           pkg-config \
+           python3-dev \
+           qtbase5-dev \
+           libqt5svg5-dev \
+           swig
+      - name: 'Configure OBS-Studio'
+        working-directory: ${{ github.workspace }}/obs-studio
+        shell: bash
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -DBUILD_CAPTIONS=YES -DDISABLE_PLUGINS=YES -DENABLE_SCRIPTING=NO -DUNIX_STRUCTURE=YES -DCMAKE_INSTALL_PREFIX=/usr ..
+      - name: 'Build OBS-Studio'
+        working-directory: ${{ github.workspace }}/obs-studio
+        shell: bash
+        run: |
+          set -e
+          cd ./build
+          make -j4 libobs obs-frontend-api
+      - name: 'Install OBS-Studio'
+        working-directory: ${{ github.workspace }}/obs-studio
+        shell: bash
+        run: |
+          cd ./build
+          sudo cp ./libobs/libobs.so /usr/lib
+          sudo cp ./UI/obs-frontend-api/libobs-frontend-api.so /usr/lib
+          sudo mkdir -p /usr/include/obs
+          sudo cp ../UI/obs-frontend-api/obs-frontend-api.h /usr/include/obs/obs-frontend-api.h
+      - name: 'Configure obs-websocket'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        shell: bash
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -DLIBOBS_INCLUDE_DIR=${{ github.workspace }}/obs-studio/libobs -DCMAKE_INSTALL_PREFIX=/usr ..
+      - name: 'Build obs-websocket'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        shell: bash
+        run: |
+          set -e
+          cd ./build
+          make -j4
+      - name: 'Set PR artifact filename'
+        shell: bash
+        run: |
+          FILENAME="obs-websocket-1-${{ env.GIT_HASH }}-1_amd64.deb"
+          echo "::set-env name=FILENAME::$FILENAME"
+      - name: 'Package ${{ env.FILENAME }}'
+        if: success()
+        working-directory: ${{ github.workspace }}/obs-websocket
+        shell: bash
+        run: |
+          VERSION="1-${{ env.GIT_HASH }}-git"
+          cd ./build
+          sudo checkinstall -y --type=debian --fstrans=no -nodoc \
+              --backup=no --deldoc=yes --install=no --pkgname=obs-websocket --pkgversion=$VERSION \
+              --pkglicense="GPLv2.0" --maintainer="${{ github.event.pusher.email }}" --pkggroup="video" \
+              --pkgsource="${{ github.event.repository.html_url }}" \
+              --requires="obs-studio,libqt5core5a,libqt5widgets5,qt5-image-formats-plugins" \
+              --pakdir="../package"
+          sudo chmod ao+r ../package/*
+          cd -
+      - name: 'Publish ${{ env.FILENAME }}'
+        if: success()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: '${{ env.GIT_HASH }}-linux'
+          path: '${{ github.workspace }}/obs-websocket/package/*.deb'
+  macos64:
+    name: "macOS 64-bit"
+    runs-on: [macos-latest]
+    if: contains(github.event.head_commit.message, '[skip ci]') != true
+    env:
+      MACOS_DEPS_VERSION: '2020-04-18'
+      QT_VERSION: '5.14.1'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/obs-websocket
+          submodules: 'recursive'
+      - name: 'Checkout OBS'
+        uses: actions/checkout@v2
+        with:
+          repository: obsproject/obs-studio
+          path: ${{ github.workspace }}/obs-studio
+          submodules: 'recursive'
+      - name: 'Get OBS-Studio git info'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=OBS_GIT_BRANCH::$(git rev-parse --abbrev-ref HEAD)
+          echo ::set-env name=OBS_GIT_HASH::$(git rev-parse --short HEAD)
+          echo ::set-env name=OBS_GIT_TAG::$(git describe --tags --abbrev=0)
+      - name: 'Checkout last OBS-Studio release (${{ env.OBS_GIT_TAG }})'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          git checkout ${{ env.OBS_GIT_TAG }}
+          git submodule update
+      - name: 'Get obs-websocket git info'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=GIT_BRANCH::${{ github.event.pull_request.head.ref }}
+          echo ::set-env name=GIT_HASH::$(git rev-parse --short HEAD)
+          echo ::set-env name=GIT_TAG::$(git describe --tags --abbrev=0)
+      - name: 'Install prerequisites (Homebrew)'
+        shell: bash
+        run: |
+          brew bundle --file ${{ github.workspace }}/obs-websocket/CI/macos/Brewfile
+      - name: 'Install prerequisite: Pre-built OBS dependencies'
+        shell: bash
+        run: |
+          curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.MACOS_DEPS_VERSION }}/osx-deps-${{ env.MACOS_DEPS_VERSION }}.tar.gz
+          tar -xf ${{ github.workspace }}/osx-deps-${{ env.MACOS_DEPS_VERSION }}.tar.gz -C "/tmp"
+      - name: 'Configure OBS Studio'
+        shell: bash
+        working-directory: ${{ github.workspace }}/obs-studio
+        run: |
+          mkdir build
+          cd build
+          cmake -DBUILD_CAPTIONS=YES -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DENABLE_SCRIPTING=NO -DDepsPath=/tmp/obsdeps -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt/${{ env.QT_VERSION }}/lib/cmake ..
+      - name: 'Build OBS Studio libraries'
+        working-directory: ${{ github.workspace }}/obs-studio
+        shell: bash
+        run: |
+          set -e
+          cd ./build
+          make -j4 libobs obs-frontend-api
+      - name: 'Configure obs-websocket'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        shell: bash
+        run: |
+          mkdir build
+          cd build
+          cmake -DQTDIR=/usr/local/Cellar/qt/${{ env.QT_VERSION }} -DLIBOBS_INCLUDE_DIR=${{ github.workspace }}/obs-studio/libobs -DLIBOBS_LIB=${{ github.workspace }}/obs-studio/libobs -DOBS_FRONTEND_LIB="${{ github.workspace }}/obs-studio/build/UI/obs-frontend-api/libobs-frontend-api.dylib" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr ..
+      - name: 'Build obs-websocket'
+        working-directory: ${{ github.workspace }}/obs-websocket
+        shell: bash
+        run: |
+          set -e
+          cd ./build
+          make -j4
+      - name: 'Install prerequisite: Packages app'
+        if: success()
+        shell: bash
+        run: |
+          curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
+          sudo installer -pkg ${{ github.workspace }}/Packages.pkg -target /
+      - name: 'Set PR artifact filename'
+        shell: bash
+        run: |
+          FILENAME_UNSIGNED="obs-websocket-${{ env.GIT_HASH }}-macOS-Unsigned.pkg"
+          echo "::set-env name=FILENAME_UNSIGNED::$FILENAME_UNSIGNED"
+      - name: 'Fix linked dynamic library paths'
+        if: success()
+        working-directory: ${{ github.workspace }}/obs-websocket
+        shell: bash
+        run: |
+          install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./build/obs-websocket.so
+          install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./build/obs-websocket.so
+          install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./build/obs-websocket.so
+          echo "Dependencies for obs-websocket"
+          otool -L ./build/obs-websocket.so
+      - name: 'Package ${{ env.FILENAME }}'
+        if: success()
+        working-directory: ./obs-websocket
+        shell: bash
+        run: |
+          packagesbuild ./CI/macos/obs-websocket.pkgproj
+          mv ./release/obs-websocket.pkg ./release/${{ env.FILENAME_UNSIGNED }}
+      - name: 'Publish ${{ env.FILENAME_UNSIGNED }} artifact'
+        if: success()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: '${{ env.GIT_HASH }}-macOS'
+          path: ${{ github.workspace }}/obs-websocket/release/*.pkg

--- a/CI/macos/Brewfile
+++ b/CI/macos/Brewfile
@@ -1,0 +1,10 @@
+tap "akeru-inc/tap"
+brew "jack"
+brew "speexdsp"
+brew "cmake"
+brew "freetype"
+brew "fdk-aac"
+brew "https://gist.githubusercontent.com/DDRBoxman/9c7a2b08933166f4b61ed9a44b242609/raw/ef4de6c587c6bd7f50210eccd5bd51ff08e6de13/qt.rb"
+brew "swig", link: false
+brew "https://gist.githubusercontent.com/DDRBoxman/4cada55c51803a2f963fa40ce55c9d3e/raw/572c67e908bfbc1bcb8c476ea77ea3935133f5b5/swig.rb"
+brew "akeru-inc/tap/xcnotary"


### PR DESCRIPTION
This PR adapts current CI scripts for use with Github Actions. As the workflow is not relying on the existing scripts, it can be tested and used independently from current CI implementation.

Further notes:
* Workflow was tested on my own fork, artifacts were checked on macOS and Windows
* This workflow only runs CI for pull requests and pushes to the current main branch `4.x-current` - there is an additional pull request just for tags/releases
* Currently only prior OBS builds on Windows (32bit&64bit) are cached between runs, as I couldn't get the same functionality to work on macOS or Linux (even with caching Windows builds are still the slowest)
* Artifacts are generated for every run, macOS artifacts are unsigned
* Artifact naming scheme is `obs-websocket-SHORT_COMMIT_HASH-OS` with slight variations for `deb` packages and windows installers
* macOS build process uses Homebrew bundle to manage dependencies
* QT versions and pre-built dependency versions configurable via environment variables

