### PR TITLE
Suppress websocketpp logging entries

### DIFF
--- a/src/WSServer.cpp
+++ b/src/WSServer.cpp
@@ -44,6 +44,7 @@ WSServer::WSServer()
 	  _connections(),
 	  _clMutex(QMutex::Recursive)
 {
+        _server.get_alog().clear_channels(websocketpp::log::alevel::frame_header | websocketpp::log::alevel::frame_payload | websocketpp::log::alevel::control);
 	_server.init_asio();
 #ifndef _WIN32
 	_server.set_reuse_addr(true);


### PR DESCRIPTION
Regardless of whether debug is enabled or disabled, websocketpp seems to dump its log messages into the OBS console. These are annoying and clutter up logs. They are also redundant if debug logging is enabled.