### PR TITLE
[Bug Fix] Fix FreeType2 source type recognition

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -15,7 +15,7 @@ bool isTextGDIPlusSource(const QString& sourceKind)
 
 bool isTextFreeType2Source(const QString& sourceKind)
 {
-	return (sourceKind == "text_ft2" || sourceKind == "text_ft2_v2" || sourceKind == "text_ft2_source" || sourceKind == "text_ft2_source_v2");
+	return (sourceKind == "text_ft2_source" || sourceKind == "text_ft2_source_v2");
 }
 
 /**

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -15,7 +15,7 @@ bool isTextGDIPlusSource(const QString& sourceKind)
 
 bool isTextFreeType2Source(const QString& sourceKind)
 {
-	return (sourceKind == "text_ft2" || sourceKind == "text_ft2_v2");
+	return (sourceKind == "text_ft2" || sourceKind == "text_ft2_v2" || sourceKind == "text_ft2_source" || sourceKind == "text_ft2_source_v2");
 }
 
 /**


### PR DESCRIPTION
OBS appears to be using a new format for the FreeType2 source, so we add the new kinds.

One thing I'm unsure on is if anything still uses the old naming stuff `text_ft2`/`text_ft2_v2`, since if not then we should not check.