### PR TITLE
[Bug Fix] Don't build with captions on MacOS

### DIFF
--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -34,7 +34,6 @@ git checkout $OBSLatestTag
 mkdir build && cd build
 echo "[obs-websocket] Building obs-studio.."
 cmake .. \
-	-DBUILD_CAPTIONS=true \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
 	-DDISABLE_PLUGINS=true \
     -DENABLE_SCRIPTING=0 \


### PR DESCRIPTION
According to [this](https://github.com/obsproject/obs-studio/blob/master/UI/frontend-plugins/frontend-tools/CMakeLists.txt#L73), captions support is not available on MacOS (apparently it uses windows-only apis, so we should not build it here.