### PR TITLE
Fix install dir on Ubuntu by using new cmake flag

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,7 +24,7 @@ sudo apt-get install libboost-all-dev
 git clone --recursive https://github.com/Palakis/obs-websocket.git
 cd obs-websocket
 mkdir build && cd build
-cmake -DLIBOBS_INCLUDE_DIR="<path to the libobs sub-folder in obs-studio's source code>" -DCMAKE_INSTALL_PREFIX=/usr ..
+cmake -DLIBOBS_INCLUDE_DIR="<path to the libobs sub-folder in obs-studio's source code>" -DCMAKE_INSTALL_PREFIX=/usr -DUSE_UBUNTU_FIX=true ..
 make -j4
 sudo make install
 ```

--- a/CI/build-ubuntu.sh
+++ b/CI/build-ubuntu.sh
@@ -2,5 +2,5 @@
 set -ex
 
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DUSE_UBUNTU_FIX=true ..
 make -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,10 +190,9 @@ if(UNIX AND NOT APPLE)
 	if(${USE_UBUNTU_FIX})
 		install(TARGETS obs-websocket
 			LIBRARY DESTINATION "/usr/lib/obs-plugins")
-	else()
-		install(TARGETS obs-websocket
-			LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
 	endif()
+	install(TARGETS obs-websocket
+		LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
 
 	install(FILES ${locale_files}
 		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/obs-websocket/locale")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,8 +187,13 @@ if(UNIX AND NOT APPLE)
 
 	file(GLOB locale_files data/locale/*.ini)
 
-	install(TARGETS obs-websocket
-		LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
+	if(${USE_UBUNTU_FIX})
+		install(TARGETS obs-websocket
+			LIBRARY DESTINATION "/usr/lib/obs-plugins")
+	else()
+		install(TARGETS obs-websocket
+			LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
+	endif()
 
 	install(FILES ${locale_files}
 		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/obs-websocket/locale")


### PR DESCRIPTION
After #478, building on Ubuntu was broken. This adds a flag for Ubuntu users which installs the plugin binaries into the correct directory.