### PR TITLE
Requests: Add GetTransitionPosition

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -84,6 +84,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 	{ "SetCurrentTransition", &WSRequestHandler::SetCurrentTransition },
 	{ "SetTransitionDuration", &WSRequestHandler::SetTransitionDuration },
 	{ "GetTransitionDuration", &WSRequestHandler::GetTransitionDuration },
+	{ "GetTransitionPosition", &WSRequestHandler::GetTransitionPosition },
 
 	{ "SetVolume", &WSRequestHandler::SetVolume },
 	{ "GetVolume", &WSRequestHandler::GetVolume },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -99,6 +99,9 @@ class WSRequestHandler {
 		RpcResponse GetTransitionList(const RpcRequest&);
 		RpcResponse GetCurrentTransition(const RpcRequest&);
 		RpcResponse SetCurrentTransition(const RpcRequest&);
+		RpcResponse SetTransitionDuration(const RpcRequest&);
+		RpcResponse GetTransitionDuration(const RpcRequest&);
+		RpcResponse GetTransitionPosition(const RpcRequest&);
 
 		RpcResponse SetVolume(const RpcRequest&);
 		RpcResponse GetVolume(const RpcRequest&);
@@ -137,9 +140,6 @@ class WSRequestHandler {
 #if BUILD_CAPTIONS
 		RpcResponse SendCaptions(const RpcRequest&);
 #endif
-
-		RpcResponse SetTransitionDuration(const RpcRequest&);
-		RpcResponse GetTransitionDuration(const RpcRequest&);
 
 		RpcResponse GetStudioModeStatus(const RpcRequest&);
 		RpcResponse GetPreviewScene(const RpcRequest&);

--- a/src/WSRequestHandler_Transitions.cpp
+++ b/src/WSRequestHandler_Transitions.cpp
@@ -120,3 +120,22 @@ RpcResponse WSRequestHandler::GetTransitionDuration(const RpcRequest& request) {
 	obs_data_set_int(response, "transition-duration", obs_frontend_get_transition_duration());
 	return request.success(response);
 }
+
+/**
+ * Get the position of the current transition.
+ *
+ * @return {double} `position` current transition position. This value will be between 0.0 and 1.0. Note: Transition returns 1.0 when not active.
+ *
+ * @api requests
+ * @name GetTransitionPosition
+ * @category transitions
+ * @since 4.8.0
+ */
+RpcResponse WSRequestHandler::GetTransitionPosition(const RpcRequest& request) {
+	OBSSourceAutoRelease currentTransition = obs_frontend_get_current_transition();
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_double(response, "position", obs_transition_get_time(currentTransition));
+
+	return request.success(response);
+}


### PR DESCRIPTION
Gets the current position of the active transition. Works on manual and also auto transition modes. Originally added to #439 but removed since #439 requires OBS changes and wont be ready for 4.8.