### PR TITLE
Requests: Add SetSourceName (renaming sources)

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -91,6 +91,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 	{ "ToggleMute", &WSRequestHandler::ToggleMute },
 	{ "SetMute", &WSRequestHandler::SetMute },
 	{ "GetMute", &WSRequestHandler::GetMute },
+	{ "SetSourceName", &WSRequestHandler::SetSourceName },
 	{ "SetSyncOffset", &WSRequestHandler::SetSyncOffset },
 	{ "GetSyncOffset", &WSRequestHandler::GetSyncOffset },
 	{ "GetSpecialSources", &WSRequestHandler::GetSpecialSources },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -108,6 +108,7 @@ class WSRequestHandler {
 		RpcResponse ToggleMute(const RpcRequest&);
 		RpcResponse SetMute(const RpcRequest&);
 		RpcResponse GetMute(const RpcRequest&);
+		RpcResponse SetSourceName(const RpcRequest&);
 		RpcResponse SetSyncOffset(const RpcRequest&);
 		RpcResponse GetSyncOffset(const RpcRequest&);
 		RpcResponse GetSpecialSources(const RpcRequest&);


### PR DESCRIPTION
Adds the `SetSourceName` request which can be used to rename sources.

Also works on scenes since scenes in OBS are also sources.

Closes #507 