### PR TITLE
Requests: Fix useDecibel response when volume is -infinity

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -192,6 +192,10 @@ RpcResponse WSRequestHandler::GetVolume(const RpcRequest& request)
 	if (useDecibel) {
 		volume = obs_mul_to_db(volume);
 	}
+	
+	if (volume == -INFINITY) {
+		volume = -100.0;
+	}
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "name", obs_source_get_name(source));


### PR DESCRIPTION
When the volume in OBS is -infinity, `GetVolume` returns a decibel value of
either 0, or in some cases no `volume` property at all. This makes `GetVolume`
return a decibel value of -100.0 if the real volume is -infinity.

Fixes #528 