### PR TITLE
Bugfix/correct position data type

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -684,8 +684,8 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
 
 /**
  * @typedef {Object} `SceneItemTransform`
- * @property {int} `position.x` The x position of the scene item from the left.
- * @property {int} `position.y` The y position of the scene item from the top.
+ * @property {double} `position.x` The x position of the scene item from the left.
+ * @property {double} `position.y` The y position of the scene item from the top.
  * @property {int} `position.alignment` The point on the scene item that the item is manipulated from.
  * @property {double} `rotation` The clockwise rotation of the scene item in degrees around the point of alignment.
  * @property {double} `scale.x` The x-scale factor of the scene item.

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -79,8 +79,8 @@ RpcResponse WSRequestHandler::GetSceneItemProperties(const RpcRequest& request) 
 * @param {String | Object} `item` Scene Item name (if this field is a string) or specification (if it is an object).
 * @param {String (optional)} `item.name` Scene Item name (if the `item` field is an object)
 * @param {int (optional)} `item.id` Scene Item ID (if the `item` field is an object)
-* @param {int (optional)} `position.x` The new x position of the source.
-* @param {int (optional)} `position.y` The new y position of the source.
+* @param {double (optional)} `position.x` The new x position of the source.
+* @param {double (optional)} `position.y` The new y position of the source.
 * @param {int (optional)} `position.alignment` The new alignment of the source.
 * @param {double (optional)} `rotation` The new clockwise rotation of the item in degrees.
 * @param {double (optional)} `scale.x` The new x scale of the item.
@@ -134,10 +134,10 @@ RpcResponse WSRequestHandler::SetSceneItemProperties(const RpcRequest& request) 
 		vec2 newPosition = oldPosition;
 
 		if (obs_data_has_user_value(reqPosition, "x")) {
-			newPosition.x = obs_data_get_int(reqPosition, "x");
+			newPosition.x = obs_data_get_double(reqPosition, "x");
 		}
 		if (obs_data_has_user_value(reqPosition, "y")) {
-			newPosition.y = obs_data_get_int(reqPosition, "y");
+			newPosition.y = obs_data_get_double(reqPosition, "y");
 		}
 
 		if (obs_data_has_user_value(reqPosition, "alignment")) {

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -13,8 +13,8 @@
 *
 * @return {String} `name` Scene Item name.
 * @return {int} `itemId` Scene Item ID.
-* @return {int} `position.x` The x position of the source from the left.
-* @return {int} `position.y` The y position of the source from the top.
+* @return {double} `position.x` The x position of the source from the left.
+* @return {double} `position.y` The y position of the source from the top.
 * @return {int} `position.alignment` The point on the source that the item is manipulated from.
 * @return {double} `rotation` The clockwise rotation of the item in degrees around the point of alignment.
 * @return {double} `scale.x` The x-scale factor of the source.


### PR DESCRIPTION
Fixed the data type of "position.x/y" for all requests from int to double since it is handled as double in OBS-Studio.

Also the position was already handled as double in the deprecated "SetSceneItemPosition" request.

This has been successfully tested on Windows 10.