### PR TITLE
Create source base functionality (modelled after #524)

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -90,6 +90,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 	{ "GetTransitionDuration", &WSRequestHandler::GetTransitionDuration },
 	{ "GetTransitionPosition", &WSRequestHandler::GetTransitionPosition },
 
+	{ "CreateSource", &WSRequestHandler::CreateSource },
 	{ "SetVolume", &WSRequestHandler::SetVolume },
 	{ "GetVolume", &WSRequestHandler::GetVolume },
 	{ "ToggleMute", &WSRequestHandler::ToggleMute },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -107,6 +107,7 @@ class WSRequestHandler {
 		RpcResponse GetTransitionDuration(const RpcRequest&);
 		RpcResponse GetTransitionPosition(const RpcRequest&);
 
+		RpcResponse CreateSource(const RpcRequest&);
 		RpcResponse SetVolume(const RpcRequest&);
 		RpcResponse GetVolume(const RpcRequest&);
 		RpcResponse ToggleMute(const RpcRequest&);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -156,6 +156,31 @@ RpcResponse WSRequestHandler::GetSourceTypesList(const RpcRequest& request)
 }
 
 /**
+ * Create a new source.
+ *
+ * @param {String} `sourceName` Name of the source to create.
+ *
+ * @api requests
+ * @name CreateSource
+ * @category sources
+ * @since 4.9.0
+ */
+RpcResponse WSRequestHandler::CreateSource(const RpcRequest& request) {
+	if (!request.hasField("sourceName")) {
+		return request.failed("missing request parameters");
+	}
+
+	const char* sourceName = obs_data_get_string(request.parameters(), "sourceName");
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName);
+
+	if (source) {
+		return request.failed("source with this name already exists");
+	}
+	obs_scene_create(sourceName);
+	return request.success();
+}
+
+/**
 * Get the volume of the specified source. Default response uses mul format, NOT SLIDER PERCENTAGE.
 *
 * @param {String} `source` Source name.


### PR DESCRIPTION
hey. this adds a CreateSource request similar to #524 

CreateScene and CreateSource are equivalent right now, but it feels good to have both methods: to help with intuition / searchability for users of the library, and to allow for divergence / expansion down the line

also working on a PR adding CreateSceneItem({ parent, child }) so sources can be attached to scenes