### PR TITLE
[Bug Fix] Reenable building with captions on MacOS

### DIFF
--- a/CI/install-build-obs-macos.sh
+++ b/CI/install-build-obs-macos.sh
@@ -34,6 +34,7 @@ git checkout $OBSLatestTag
 mkdir build && cd build
 echo "[obs-websocket] Building obs-studio.."
 cmake .. \
+	-DBUILD_CAPTIONS=true \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
 	-DDISABLE_PLUGINS=true \
     -DENABLE_SCRIPTING=0 \


### PR DESCRIPTION
This reverts #477. OBS on MacOS supports closed caption encoding. The Windows-only dependencies [here](https://github.com/obsproject/obs-studio/blob/master/UI/frontend-plugins/frontend-tools/CMakeLists.txt#L73) are only related to audio capture, not closed caption encoding.

OBS Studio 25.0.8 and latest version of obs-websocket 4.x built with `BUILD_CAPTIONS=true` receiving an event originating from obs-websocket-js:
```
20:14:31.677: [obs-websocket] Request >> '{"text":"hello world! Mon Jun 29 2020 20:14:31 GMT-0500 (Central Daylight Time)","request-type":"SendCaptions","message-id":"39"}'
20:14:31.677: [obs-websocket] Response << '{
20:14:31.677:     "message-id": "39",
20:14:31.677:     "status": "ok"
20:14:31.677: }'
```

Closed captions appearing in Twitch stream:
<img width="615" alt="Screen Shot 2020-06-29 at 8 13 57 PM" src="https://user-images.githubusercontent.com/3038600/86072444-2f771880-ba47-11ea-8992-228a9a4e0a18.png">

