### PR TITLE
Requests, Events: Add support for Audio Active

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -271,6 +271,8 @@ void WSEvents::connectSourceSignals(obs_source_t* source) {
 	signal_handler_connect(sh, "volume", OnSourceVolumeChange, this);
 	signal_handler_connect(sh, "audio_sync", OnSourceAudioSyncOffsetChanged, this);
 	signal_handler_connect(sh, "audio_mixers", OnSourceAudioMixersChanged, this);
+	signal_handler_connect(sh, "audio_activate", OnSourceAudioActivated, this);
+	signal_handler_connect(sh, "audio_deactivate", OnSourceAudioDeactivated, this);
 
 	signal_handler_connect(sh, "filter_add", OnSourceFilterAdded, this);
 	signal_handler_connect(sh, "filter_remove", OnSourceFilterRemoved, this);
@@ -303,6 +305,8 @@ void WSEvents::disconnectSourceSignals(obs_source_t* source) {
 	signal_handler_disconnect(sh, "volume", OnSourceVolumeChange, this);
 	signal_handler_disconnect(sh, "audio_sync", OnSourceAudioSyncOffsetChanged, this);
 	signal_handler_disconnect(sh, "audio_mixers", OnSourceAudioMixersChanged, this);
+	signal_handler_disconnect(sh, "audio_activate", OnSourceAudioActivated, this);
+	signal_handler_disconnect(sh, "audio_deactivate", OnSourceAudioDeactivated, this);
 
 	signal_handler_disconnect(sh, "filter_add", OnSourceFilterAdded, this);
 	signal_handler_disconnect(sh, "filter_remove", OnSourceFilterRemoved, this);
@@ -1096,6 +1100,52 @@ void WSEvents::OnSourceMuteStateChange(void* param, calldata_t* data) {
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_bool(fields, "muted", muted);
 	self->broadcastUpdate("SourceMuteStateChanged", fields);
+}
+
+/**
+ * A source has removed audio.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name SourceAudioDeactivated
+ * @category sources
+ * @since unreleased
+ */
+void WSEvents::OnSourceAudioDeactivated(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	self->broadcastUpdate("SourceAudioDeactivated", fields);
+}
+
+/**
+ * A source has added audio.
+ *
+ * @return {String} `sourceName` Source name
+ *
+ * @api events
+ * @name SourceAudioActivated
+ * @category sources
+ * @since unreleased
+ */
+void WSEvents::OnSourceAudioActivated(void* param, calldata_t* data) {
+	auto self = reinterpret_cast<WSEvents*>(param);
+
+	OBSSource source = calldata_get_pointer<obs_source_t>(data, "source");
+	if (!source) {
+		return;
+	}
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
+	self->broadcastUpdate("SourceAudioActivated", fields);
 }
 
 /**

--- a/src/WSEvents.h
+++ b/src/WSEvents.h
@@ -126,6 +126,8 @@ private:
 	static void OnSourceMuteStateChange(void* param, calldata_t* data);
 	static void OnSourceAudioSyncOffsetChanged(void* param, calldata_t* data);
 	static void OnSourceAudioMixersChanged(void* param, calldata_t* data);
+	static void OnSourceAudioActivated(void* param, calldata_t* data);
+	static void OnSourceAudioDeactivated(void* param, calldata_t* data);
 
 	static void OnSourceRename(void* param, calldata_t* data);
 

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -95,6 +95,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 	{ "ToggleMute", &WSRequestHandler::ToggleMute },
 	{ "SetMute", &WSRequestHandler::SetMute },
 	{ "GetMute", &WSRequestHandler::GetMute },
+	{ "GetAudioActive", &WSRequestHandler::GetAudioActive },
 	{ "SetSourceName", &WSRequestHandler::SetSourceName },
 	{ "SetSyncOffset", &WSRequestHandler::SetSyncOffset },
 	{ "GetSyncOffset", &WSRequestHandler::GetSyncOffset },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -112,6 +112,7 @@ class WSRequestHandler {
 		RpcResponse ToggleMute(const RpcRequest&);
 		RpcResponse SetMute(const RpcRequest&);
 		RpcResponse GetMute(const RpcRequest&);
+		RpcResponse GetAudioActive(const RpcRequest&);
 		RpcResponse SetSourceName(const RpcRequest&);
 		RpcResponse SetSyncOffset(const RpcRequest&);
 		RpcResponse GetSyncOffset(const RpcRequest&);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -342,6 +342,40 @@ RpcResponse WSRequestHandler::ToggleMute(const RpcRequest& request)
 }
 
 /**
+* Get the audio's active status of a specified source.
+*
+* @param {String} `sourceName` Source name.
+*
+* @return {boolean} `audioActive` Audio active status of the source.
+*
+* @api requests
+* @name GetAudioActive
+* @category sources
+* @since 4.9.0
+*/
+RpcResponse WSRequestHandler::GetAudioActive(const RpcRequest& request)
+{
+	if (!request.hasField("sourceName")) {
+		return request.failed("missing request parameters");
+	}
+
+	QString sourceName = obs_data_get_string(request.parameters(), "sourceName");
+	if (sourceName.isEmpty()) {
+		return request.failed("invalid request parameters");
+	}
+
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		return request.failed("specified source doesn't exist");
+	}
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_bool(response, "audioActive", obs_source_audio_active(source));
+
+	return request.success(response);
+}
+
+/**
 * Sets (aka rename) the name of a source. Also works with scenes since scenes are technically sources in OBS.
 *
 * Note: If the new name already exists as a source, OBS will automatically modify the name to not interfere.

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -351,7 +351,7 @@ RpcResponse WSRequestHandler::ToggleMute(const RpcRequest& request)
 * @api requests
 * @name GetAudioActive
 * @category sources
-* @since 4.9.0
+* @since unreleased
 */
 RpcResponse WSRequestHandler::GetAudioActive(const RpcRequest& request)
 {


### PR DESCRIPTION
This is used to determine whether a Browser source has "Control audio via OBS" enabled. If true, the source should appear in a mixer.