### PR TITLE
CMakeLists: Compile for arm targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_definitions(-DASIO_STANDALONE)
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm") 
+    set(CMAKE_CXX_FLAGS "-mfpu=neon")
+endif()
+
 if (WIN32 OR APPLE)
 	include(external/FindLibObs.cmake)
 endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Adding the -mfpu=neon flag to the arm target so that it can build on arm devices like raspberry pi

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the merge of pr [#3180 on obs-studio](https://github.com/obsproject/obs-studio/pull/3180), we can now build and install the plugin for raspberry pi and other arm devices.  It will fix the following issue:
<img width="852" alt="Screen Shot 2020-07-18 at 2 00 15 PM" src="https://user-images.githubusercontent.com/13398476/87859969-11426100-c8ff-11ea-9650-b46013855915.png">

<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
I ran the code on a Raspberry Pi 3B+ running Raspberry Pi OS 2015-05-05 with this [build script](https://github.com/venepe/install-obs-raspberry-pi.git).  I also ran it on a MacBook running Catalina.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

