### PR TITLE
Utils(GetTrayIcon): refactor with frontend API function

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -485,11 +485,8 @@ QString Utils::OBSVersionString() {
 }
 
 QSystemTrayIcon* Utils::GetTrayIcon() {
-	QMainWindow* main = (QMainWindow*)obs_frontend_get_main_window();
-	if (!main) return nullptr;
-
-	QList<QSystemTrayIcon*> trays = main->findChildren<QSystemTrayIcon*>();
-	return trays.isEmpty() ? nullptr : trays.first();
+	void* systemTray = obs_frontend_get_system_tray();
+	return reinterpret_cast<QSystemTrayIcon*>(systemTray);
 }
 
 void Utils::SysTrayNotify(QString text,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description

Fixes a crash happening in `Utils::GetTrayIcon` by refactoring it to remove the old Qt `findChildren` hack and using `obs_frontend_get_system_tray` instead.

### Motivation and Context

Fixes #569 

### How Has This Been Tested?

Tested on Windows 10 2004 with t2t2's obs-tablet-remote and tray notifications enabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

