### PR TITLE
Docs: Fix requests marked as "unreleased"

### DIFF
--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -184,7 +184,7 @@ RpcResponse WSRequestHandler::ReorderSceneItems(const RpcRequest& request) {
  * @api requests
  * @name SetSceneTransitionOverride
  * @category scenes
- * @since unreleased
+ * @since 4.8.0
  */
 RpcResponse WSRequestHandler::SetSceneTransitionOverride(const RpcRequest& request) {
 	if (!request.hasField("sceneName") || !request.hasField("transitionName")) {
@@ -230,7 +230,7 @@ RpcResponse WSRequestHandler::SetSceneTransitionOverride(const RpcRequest& reque
  * @api requests
  * @name RemoveSceneTransitionOverride
  * @category scenes
- * @since unreleased
+ * @since 4.8.0
  */
 RpcResponse WSRequestHandler::RemoveSceneTransitionOverride(const RpcRequest& request) {
 	if (!request.hasField("sceneName")) {
@@ -266,7 +266,7 @@ RpcResponse WSRequestHandler::RemoveSceneTransitionOverride(const RpcRequest& re
  * @api requests
  * @name GetSceneTransitionOverride
  * @category scenes
- * @since unreleased
+ * @since 4.8.0
  */
 RpcResponse WSRequestHandler::GetSceneTransitionOverride(const RpcRequest& request) {
 	if (!request.hasField("sceneName")) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
The requests had `unreleased` marked, leading people to think that the already-released requests were coming in v4.8.0

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue) 
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

