### PR TITLE
requests(GetSceneItemList): fallback to current scene if sceneName is not specified

### DIFF
--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -34,7 +34,7 @@ RpcResponse WSRequestHandler::GetSceneItemList(const RpcRequest& request) {
 	const char* sceneName = obs_data_get_string(request.parameters(), "sceneName");
 
 	OBSSourceAutoRelease sceneSource;
-	if (sceneName) {
+	if (sceneName && strcmp(sceneName, "") != 0) {
 		sceneSource = obs_get_source_by_name(sceneName);
 	} else {
 		sceneSource = obs_frontend_get_current_scene();

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -31,12 +31,15 @@ void AddSourceHelper(void *_data, obs_scene_t *scene) {
 * @since unreleased
 */
 RpcResponse WSRequestHandler::GetSceneItemList(const RpcRequest& request) {
-	if (!request.hasField("sceneName")) {
-		return request.failed("missing request parameters");
+	const char* sceneName = obs_data_get_string(request.parameters(), "sceneName");
+
+	OBSSourceAutoRelease sceneSource;
+	if (sceneName) {
+		sceneSource = obs_get_source_by_name(sceneName);
+	} else {
+		sceneSource = obs_frontend_get_current_scene();
 	}
 
-	const char* sceneName = obs_data_get_string(request.parameters(), "sceneName");
-	OBSSourceAutoRelease sceneSource = obs_get_source_by_name(sceneName);
 	OBSScene scene = obs_scene_from_source(sceneSource);
 	if (!scene) {
 		return request.failed("requested scene is invalid or doesnt exist");

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -17,7 +17,7 @@ void AddSourceHelper(void *_data, obs_scene_t *scene) {
 /**
 * Get a list of all scene items in a scene.
 *
-* @param {String} `sceneName` Name of the scene to get the list of scene items from.
+* @param {String (optional)} `sceneName` Name of the scene to get the list of scene items from. Defaults to the current scene if not specified.
 *
 * @return {Array<Object>} `sceneItems` Array of scene items
 * @return {int} `sceneItems.*.itemId` Unique item id of the source item

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -19,6 +19,7 @@ void AddSourceHelper(void *_data, obs_scene_t *scene) {
 *
 * @param {String (optional)} `sceneName` Name of the scene to get the list of scene items from. Defaults to the current scene if not specified.
 *
+* @return {String} `sceneName` Name of the requested (or current) scene
 * @return {Array<Object>} `sceneItems` Array of scene items
 * @return {int} `sceneItems.*.itemId` Unique item id of the source item
 * @return {String} `sceneItems.*.sourceKind` ID if the scene item's source. For example `vlc_source` or `image_source`
@@ -79,6 +80,7 @@ RpcResponse WSRequestHandler::GetSceneItemList(const RpcRequest& request) {
 	obs_scene_enum_items(scene, sceneItemEnumProc, sceneItemArray);
 
 	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_string(response, "sceneName", obs_source_get_name(sceneSource));
 	obs_data_set_array(response, "sceneItems", sceneItemArray);
 
 	return request.success(response);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description

Makes `GetSceneItemList` look for scene items in the current scene if the `sceneName` parameter is not specified.

### Motivation and Context

Making it more in line with how the scene item functions behave with their scene name parameter. 

### How Has This Been Tested?

Tested on Windows 10 2004 with OBS 25.0.8

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Enhancement (modification to a current event/request which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

