### PR TITLE
Requests: Add hotkeys press events

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -44,6 +44,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 	{ "BroadcastCustomMessage", &WSRequestHandler::BroadcastCustomMessage },
 
 	{ "ProcessHotkeyByName", &WSRequestHandler::ProcessHotkeyByName },
+	{ "ProcessHotkeyByCombination", &WSRequestHandler::ProcessHotkeyByCombination },
 
 	{ "SetCurrentScene", &WSRequestHandler::SetCurrentScene },
 	{ "GetCurrentScene", &WSRequestHandler::GetCurrentScene },

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -43,8 +43,8 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 
 	{ "BroadcastCustomMessage", &WSRequestHandler::BroadcastCustomMessage },
 
-	{ "ProcessHotkeyByName", &WSRequestHandler::ProcessHotkeyByName },
-	{ "ProcessHotkeyByCombination", &WSRequestHandler::ProcessHotkeyByCombination },
+	{ "TriggerHotkeyByName", &WSRequestHandler::TriggerHotkeyByName },
+	{ "TriggerHotkeyBySequence", &WSRequestHandler::TriggerHotkeyBySequence },
 
 	{ "SetCurrentScene", &WSRequestHandler::SetCurrentScene },
 	{ "GetCurrentScene", &WSRequestHandler::GetCurrentScene },

--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -43,6 +43,8 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 
 	{ "BroadcastCustomMessage", &WSRequestHandler::BroadcastCustomMessage },
 
+	{ "ProcessHotkeyByName", &WSRequestHandler::ProcessHotkeyByName },
+
 	{ "SetCurrentScene", &WSRequestHandler::SetCurrentScene },
 	{ "GetCurrentScene", &WSRequestHandler::GetCurrentScene },
 	{ "GetSceneList", &WSRequestHandler::GetSceneList },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -61,6 +61,8 @@ class WSRequestHandler {
 
 		RpcResponse BroadcastCustomMessage(const RpcRequest&);
 
+		RpcResponse ProcessHotkeyByName(const RpcRequest&);
+
 		RpcResponse SetCurrentScene(const RpcRequest&);
 		RpcResponse GetCurrentScene(const RpcRequest&);
 		RpcResponse GetSceneList(const RpcRequest&);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -61,8 +61,8 @@ class WSRequestHandler {
 
 		RpcResponse BroadcastCustomMessage(const RpcRequest&);
 
-		RpcResponse ProcessHotkeyByName(const RpcRequest&);
-		RpcResponse ProcessHotkeyByCombination(const RpcRequest&);
+		RpcResponse TriggerHotkeyByName(const RpcRequest&);
+		RpcResponse TriggerHotkeyBySequence(const RpcRequest&);
 
 		RpcResponse SetCurrentScene(const RpcRequest&);
 		RpcResponse GetCurrentScene(const RpcRequest&);

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -62,6 +62,7 @@ class WSRequestHandler {
 		RpcResponse BroadcastCustomMessage(const RpcRequest&);
 
 		RpcResponse ProcessHotkeyByName(const RpcRequest&);
+		RpcResponse ProcessHotkeyByCombination(const RpcRequest&);
 
 		RpcResponse SetCurrentScene(const RpcRequest&);
 		RpcResponse GetCurrentScene(const RpcRequest&);

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -345,3 +345,24 @@ RpcResponse WSRequestHandler::OpenProjector(const RpcRequest& request) {
 	obs_frontend_open_projector(type, monitor, geometry, name);
 	return request.success();
 }
+
+/**
+* Executes hotkey routine, identified by hotkey unique name
+*
+* @param {String} `name` Unique name of the hotkey, as defined when registering the hotkey (e.g. "ReplayBuffer.Save")
+*
+* @api requests
+* @name ProcessHotkeyByName
+* @category general
+* @since unreleased
+*/
+RpcResponse WSRequestHandler::ProcessHotkeyByName(const RpcRequest& request) {
+	const char* name = obs_data_get_string(request.parameters(), "name");
+
+	obs_hotkey_t* hk = Utils::FindHotkeyByName(name);
+	if (!hk) {
+		return request.failed("Hotkey not found");
+	}
+	obs_hotkey_trigger_routed_callback(obs_hotkey_get_id(hk), true);
+	return request.success();
+}

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -356,7 +356,7 @@ RpcResponse WSRequestHandler::OpenProjector(const RpcRequest& request) {
 * @category general
 * @since unreleased
 */
-RpcResponse WSRequestHandler::ProcessHotkeyByName(const RpcRequest& request) {
+RpcResponse WSRequestHandler::TriggerHotkeyByName(const RpcRequest& request) {
 	const char* name = obs_data_get_string(request.parameters(), "name");
 
 	obs_hotkey_t* hk = Utils::FindHotkeyByName(name);
@@ -378,7 +378,7 @@ RpcResponse WSRequestHandler::ProcessHotkeyByName(const RpcRequest& request) {
 * @category general
 * @since unreleased
 */
-RpcResponse WSRequestHandler::ProcessHotkeyByCombination(const RpcRequest& request) {
+RpcResponse WSRequestHandler::TriggerHotkeyBySequence(const RpcRequest& request) {
 	if (!request.hasField("key")) {
 		return request.failed("Missing request key parameter");
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
This PR adds two new requests that allow triggering hotkeys callback functions over websocket. The hotkey can be defined either by its unique name (the one used during registration) or by specifing the combination of keys associated to trigger it. In the latter, if the same combination has been set for multiple hotkeys, all of them will be triggered.

_Note_: the requests are named `ProcessHotkey `and not `PressHotkey` because no "physical" pressing event is sent/triggered, rather just the underlying callback functions are called/processed. Please let me know if you'd rather name the requests differently.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
This PR was motivated by the need to trigger script functions remotely. The requests can be easily used to trigger custom hotkeys registered within a script, and of course they also work with the default OBS hotkeys.

Related feature requests: #427, #444, #180

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 7 SP1, Windows 10 2004 (OBS 25.0.8)

The changes were tested by sending the requests via webpage using [obs-websocket-js](https://github.com/haganbmj/obs-websocket-js). For `ProcessHotkeyByName` request, both OBS default hotkeys and custom hotkeys (registered within scripts) were tested. For `ProcessHotkeyByCombination` request, tests were done with multiple key combinations (with and without modifiers), and associated to a single or multiple hotkey routines.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

