### PR TITLE
Get/Set Transition Settings

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -28,7 +28,7 @@
 
 using namespace std::placeholders;
 
-const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
+const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap{
 	{ "GetVersion", &WSRequestHandler::GetVersion },
 	{ "GetAuthRequired", &WSRequestHandler::GetAuthRequired },
 	{ "Authenticate", &WSRequestHandler::Authenticate },
@@ -96,6 +96,8 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap {
 	{ "SetTransitionDuration", &WSRequestHandler::SetTransitionDuration },
 	{ "GetTransitionDuration", &WSRequestHandler::GetTransitionDuration },
 	{ "GetTransitionPosition", &WSRequestHandler::GetTransitionPosition },
+	{ "GetTransitionSettings", &WSRequestHandler::GetTransitionSettings },
+	{ "SetTransitionSettings", &WSRequestHandler::SetTransitionSettings },
 
 	{ "SetVolume", &WSRequestHandler::SetVolume },
 	{ "GetVolume", &WSRequestHandler::GetVolume },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -113,6 +113,8 @@ class WSRequestHandler {
 		RpcResponse SetTransitionDuration(const RpcRequest&);
 		RpcResponse GetTransitionDuration(const RpcRequest&);
 		RpcResponse GetTransitionPosition(const RpcRequest&);
+		RpcResponse GetTransitionSettings(const RpcRequest&);
+		RpcResponse SetTransitionSettings(const RpcRequest&);
 
 		RpcResponse SetVolume(const RpcRequest&);
 		RpcResponse GetVolume(const RpcRequest&);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -511,6 +511,7 @@ RpcResponse WSRequestHandler::GetSourceSettings(const RpcRequest& request)
 
 	const char* sourceName = obs_data_get_string(request.parameters(), "sourceName");
 	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName);
+
 	if (!source) {
 		return request.failed("specified source doesn't exist");
 	}
@@ -571,21 +572,17 @@ RpcResponse WSRequestHandler::SetSourceSettings(const RpcRequest& request)
 		}
 	}
 
-	OBSDataAutoRelease currentSettings = obs_source_get_settings(source);
 	OBSDataAutoRelease newSettings = obs_data_get_obj(request.parameters(), "sourceSettings");
 
-	OBSDataAutoRelease sourceSettings = obs_data_create();
-	obs_data_apply(sourceSettings, currentSettings);
-	obs_data_apply(sourceSettings, newSettings);
-
-	obs_source_update(source, sourceSettings);
+	obs_source_update(source, newSettings);
 	obs_source_update_properties(source);
+
+	OBSDataAutoRelease updatedSettings = obs_source_get_settings(source);
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(response, "sourceType", obs_source_get_id(source));
-	obs_data_set_obj(response, "sourceSettings", sourceSettings);
-
+	obs_data_set_obj(response, "sourceSettings", updatedSettings);
 	return request.success(response);
 }
 

--- a/src/WSRequestHandler_Transitions.cpp
+++ b/src/WSRequestHandler_Transitions.cpp
@@ -201,6 +201,6 @@ RpcResponse WSRequestHandler::SetTransitionSettings(const RpcRequest& request) {
 	OBSDataAutoRelease updatedSettings = obs_source_get_settings(transition);
 
 	OBSDataAutoRelease response = obs_data_create();
-	obs_data_set_obj(response, "transitionSettings", updatedSettings); // TODO
+	obs_data_set_obj(response, "transitionSettings", updatedSettings);
 	return request.success(response);
 }

--- a/src/WSRequestHandler_Transitions.cpp
+++ b/src/WSRequestHandler_Transitions.cpp
@@ -139,3 +139,68 @@ RpcResponse WSRequestHandler::GetTransitionPosition(const RpcRequest& request) {
 
 	return request.success(response);
 }
+
+/**
+ * Get the current settings of a transition
+ *
+ * @param {String} `transitionName` Transition name
+ * 
+ * @return {Object} `transitionSettings` Current transition settings
+ * 
+ * @api requests
+ * @name GetTransitionSettings
+ * @category transitions
+ * @since unreleased
+ */
+RpcResponse WSRequestHandler::GetTransitionSettings(const RpcRequest& request) {
+	if (!request.hasField("transitionName")) {
+		return request.failed("missing request parameters");
+	}
+
+	const char* transitionName = obs_data_get_string(request.parameters(), "transitionName");
+	OBSSourceAutoRelease transition = Utils::GetTransitionFromName(transitionName);
+	if (!transition) {
+		return request.failed("specified transition doesn't exist");
+	}
+
+	OBSDataAutoRelease transitionSettings = obs_source_get_settings(transition);
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_obj(response, "transitionSettings", transitionSettings);
+	return request.success(response);
+}
+
+/**
+ * Change the current settings of a transition
+ *
+ * @param {String} `transitionName` Transition name
+ * @param {Object} `transitionSettings` Transition settings (they can be partial)
+ * 
+ * @return {Object} `transitionSettings` Updated transition settings
+ * 
+ * @api requests
+ * @name SetTransitionSettings
+ * @category transitions
+ * @since unreleased
+ */
+RpcResponse WSRequestHandler::SetTransitionSettings(const RpcRequest& request) {
+	if (!request.hasField("transitionName") || !request.hasField("transitionSettings")) {
+		return request.failed("missing request parameters");
+	}
+
+	const char* transitionName = obs_data_get_string(request.parameters(), "transitionName");
+	OBSSourceAutoRelease transition = Utils::GetTransitionFromName(transitionName);
+	if (!transition) {
+		return request.failed("specified transition doesn't exist");
+	}
+
+	OBSDataAutoRelease newSettings = obs_data_get_obj(request.parameters(), "transitionSettings");
+	obs_source_update(transition, newSettings);
+	obs_source_update_properties(transition);
+
+	OBSDataAutoRelease updatedSettings = obs_source_get_settings(transition);
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_obj(response, "transitionSettings", updatedSettings); // TODO
+	return request.success(response);
+}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description

This pull request adds methods to get and set transition settings (e.g.: change a stinger's video file).

It also fixes the behaviour of `SetSourceSettings`: instead of uselessly merging the current and updated settings together itself, it now relies on the same exact behaviour that libobs' does natively when calling `obs_source_update`.

### Motivation and Context

Like sources, transitions have settings. Actually, under the hood transitions _are_ sources. The thing is, currently there's no way to update transitions programmatically, as they are not exposed in the results of `GetSourcesList`. This pull request aims to address this situation.

### How Has This Been Tested?

Tested on OBS Studio v26 master running on Windows 10 64-bit

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New request/event (non-breaking)
<!--- - Documentation change (a change to documentation pages) -->
- Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

