### PR TITLE
requests(outputs): fix corrupted parameters object on MSVC when using findOutputOrFail

### DIFF
--- a/src/WSRequestHandler_Outputs.cpp
+++ b/src/WSRequestHandler_Outputs.cpp
@@ -59,7 +59,7 @@ obs_data_t* getOutputInfo(obs_output_t* output)
 	return data;
 }
 
-RpcResponse findOutputOrFail(const RpcRequest& request, std::function<RpcResponse (obs_output_t*)> callback)
+RpcResponse findOutputOrFail(const RpcRequest& request, std::function<RpcResponse (obs_output_t*, const RpcRequest&)> callback)
 {
 	if (!request.hasField("outputName")) {
 		return request.failed("missing request parameters");
@@ -71,7 +71,7 @@ RpcResponse findOutputOrFail(const RpcRequest& request, std::function<RpcRespons
 		return request.failed("specified output doesn't exist");
 	}
 
-	return callback(output);
+	return callback(output, request);
 }
 
 /**
@@ -117,7 +117,7 @@ RpcResponse WSRequestHandler::ListOutputs(const RpcRequest& request)
 */
 RpcResponse WSRequestHandler::GetOutputInfo(const RpcRequest& request)
 {
-	return findOutputOrFail(request, [request](obs_output_t* output) {
+	return findOutputOrFail(request, [](obs_output_t* output, const RpcRequest& request) {
 		OBSDataAutoRelease outputInfo = getOutputInfo(output);
 
 		OBSDataAutoRelease fields = obs_data_create();
@@ -140,7 +140,7 @@ RpcResponse WSRequestHandler::GetOutputInfo(const RpcRequest& request)
 */
 RpcResponse WSRequestHandler::StartOutput(const RpcRequest& request)
 {
-	return findOutputOrFail(request, [request](obs_output_t* output) {
+	return findOutputOrFail(request, [](obs_output_t* output, const RpcRequest& request) {
 		if (obs_output_active(output)) {
 			return request.failed("output already active");
 		}
@@ -171,7 +171,7 @@ RpcResponse WSRequestHandler::StartOutput(const RpcRequest& request)
 */
 RpcResponse WSRequestHandler::StopOutput(const RpcRequest& request)
 {
-	return findOutputOrFail(request, [request](obs_output_t* output) {
+	return findOutputOrFail(request, [](obs_output_t* output, const RpcRequest& request) {
 		if (!obs_output_active(output)) {
 			return request.failed("output not active");
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description

Fixes a crash when trying to use GetOutputInfo, StartOutput or StopOutput commands.

### Motivation and Context

Fixes #553 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10 20H2

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

