### PR TITLE
Events: provide new state of entity (in events that don't do it already)

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -550,13 +550,30 @@ void WSEvents::OnTransitionChange() {
  * The list of available transitions has been modified.
  * Transitions have been added, removed, or renamed.
  *
+ * @return {Array} `transitions` Transitions list.
+ * 
  * @api events
  * @name TransitionListChanged
  * @category transitions
  * @since 4.0.0
  */
 void WSEvents::OnTransitionListChange() {
-	broadcastUpdate("TransitionListChanged");
+	obs_frontend_source_list transitionList = {};
+	obs_frontend_get_transitions(&transitionList);
+
+	OBSDataArrayAutoRelease transitions = obs_data_array_create();
+	for (size_t i = 0; i < transitionList.sources.num; i++) {
+		OBSSource transition = transitionList.sources.array[i];
+
+		OBSDataAutoRelease obj = obs_data_create();
+		obs_data_set_string(obj, "name", obs_source_get_name(transition));
+		obs_data_array_push_back(transitions, obj);
+	}
+	obs_frontend_source_list_free(&transitionList);
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_array(fields, "transitions", transitions);
+	broadcastUpdate("TransitionListChanged", fields);
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -507,7 +507,7 @@ void WSEvents::OnSceneCollectionChange() {
 /**
  * Triggered when a scene collection is created, added, renamed, or removed.
  *
- * @return {Array} `sceneCollections` Scene collections list.
+ * @return {Array<Object>} `sceneCollections` Scene collections list.
  * @return {String} `sceneCollections.*.name` Scene collection name.
  * 
  * @api events
@@ -550,7 +550,8 @@ void WSEvents::OnTransitionChange() {
  * The list of available transitions has been modified.
  * Transitions have been added, removed, or renamed.
  *
- * @return {Array} `transitions` Transitions list.
+ * @return {Array<Object>} `transitions` Transitions list.
+ * @return {String} `transitions.*.name` Transition name.
  * 
  * @api events
  * @name TransitionListChanged
@@ -595,7 +596,7 @@ void WSEvents::OnProfileChange() {
 /**
  * Triggered when a profile is created, added, renamed, or removed.
  *
- * @return {Array} `profiles` Profiles list.
+ * @return {Array<Object>} `profiles` Profiles list.
  * @return {String} `profiles.*.name` Profile name.
  * 
  * @api events

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -572,14 +572,21 @@ void WSEvents::OnProfileChange() {
 /**
  * Triggered when a profile is created, added, renamed, or removed.
  *
+ * @return {Array} `profiles` Profiles list.
+ * @return {String} `profiles.*.name` Profile name.
+ * 
  * @api events
  * @name ProfileListChanged
  * @category profiles
  * @since 4.0.0
  */
 void WSEvents::OnProfileListChange() {
+	char** profiles = obs_frontend_get_profiles();
+	OBSDataArrayAutoRelease profilesList = Utils::StringListToArray(profiles, "name");
+	bfree(profiles);
+
 	OBSDataAutoRelease fields = obs_data_create();
-	// TODO provide new profile list
+	obs_data_set_array(fields, "profiles", profilesList);
 	broadcastUpdate("ProfileListChanged", fields);
 }
 

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -479,13 +479,17 @@ void WSEvents::OnSceneListChange() {
 /**
  * Triggered when switching to another scene collection or when renaming the current scene collection.
  *
+ * @return {String} `sceneCollection` Name of the new current scene collection.
+ * 
  * @api events
  * @name SceneCollectionChanged
  * @category scenes
  * @since 4.0.0
  */
 void WSEvents::OnSceneCollectionChange() {
-	broadcastUpdate("SceneCollectionChanged");
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "sceneCollection", obs_frontend_get_current_scene_collection());
+	broadcastUpdate("SceneCollectionChanged", fields);
 
 	OnTransitionListChange();
 	OnTransitionChange();

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -546,13 +546,17 @@ void WSEvents::OnTransitionListChange() {
 /**
  * Triggered when switching to another profile or when renaming the current profile.
  *
+ * @return {String} `profile` Name of the new current profile.
+ * 
  * @api events
  * @name ProfileChanged
  * @category profiles
  * @since 4.0.0
  */
 void WSEvents::OnProfileChange() {
-	broadcastUpdate("ProfileChanged");
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_string(fields, "profile", obs_frontend_get_current_profile());
+	broadcastUpdate("ProfileChanged", fields);
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -501,13 +501,23 @@ void WSEvents::OnSceneCollectionChange() {
 /**
  * Triggered when a scene collection is created, added, renamed, or removed.
  *
+ * @return {Array} `sceneCollections` Scene collections list.
+ * @return {String} `sceneCollections.*.name` Scene collection name.
+ * 
  * @api events
  * @name SceneCollectionListChanged
  * @category scenes
  * @since 4.0.0
  */
 void WSEvents::OnSceneCollectionListChange() {
-	broadcastUpdate("SceneCollectionListChanged");
+	char** sceneCollections = obs_frontend_get_scene_collections();
+	OBSDataArrayAutoRelease sceneCollectionsList =
+		Utils::StringListToArray(sceneCollections, "name");
+	bfree(sceneCollections);
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_array(fields, "sceneCollections", sceneCollectionsList);
+	broadcastUpdate("SceneCollectionListChanged", fields);
 }
 
 /**
@@ -568,7 +578,9 @@ void WSEvents::OnProfileChange() {
  * @since 4.0.0
  */
 void WSEvents::OnProfileListChange() {
-	broadcastUpdate("ProfileListChanged");
+	OBSDataAutoRelease fields = obs_data_create();
+	// TODO provide new profile list
+	broadcastUpdate("ProfileListChanged", fields);
 }
 
 /**

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -467,13 +467,19 @@ void WSEvents::OnSceneChange() {
  *
  * Note: This event is not fired when the scenes are reordered.
  *
+ * @return {Array<Scene>} `scenes` Scenes list.
+ * 
  * @api events
  * @name ScenesChanged
  * @category scenes
  * @since 0.3
  */
 void WSEvents::OnSceneListChange() {
-	broadcastUpdate("ScenesChanged");
+	OBSDataArrayAutoRelease scenes = Utils::GetScenes();
+
+	OBSDataAutoRelease fields = obs_data_create();
+	obs_data_set_array(fields, "scenes", scenes);
+	broadcastUpdate("ScenesChanged", fields);
 }
 
 /**


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description

Modifies the following events to provide the new state of their respective entity:
- [x] `SceneCollectionChanged`
- [x] `ProfileChanged`
- [x] `SceneCollectionListChanged`
- [x] `ProfileListChanged`
- [x] `ScenesChanged`
- [x] `TransitionListChanged`

### Motivation and Context

Fixes #380

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10 20H2

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Enhancement (modification to a current event/request which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

