### PR TITLE
Feature/current recording filename

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -696,6 +696,29 @@ bool Utils::SetFilenameFormatting(const char* filenameFormatting) {
 	return true;
 }
 
+const char* Utils::GetCurrentRecordingFilename()
+{
+	OBSOutputAutoRelease recordingOutput = obs_frontend_get_recording_output();
+	if (!recordingOutput) {
+		return nullptr;
+	}
+
+	OBSDataAutoRelease settings = obs_output_get_settings(recordingOutput);
+
+	// mimicks the behavior of BasicOutputHandler::GetRecordingFilename :
+	// try to fetch the path from the "url" property, then try "path" if the first one
+	// didn't yield any result
+	OBSDataItemAutoRelease item = obs_data_item_byname(settings, "url");
+	if (!item) {
+		item = obs_data_item_byname(settings, "path");
+		if (!item) {
+			return nullptr;
+		}
+	}
+
+	return obs_data_item_get_string(item);
+}
+
 // Transform properties copy-pasted from WSRequestHandler_SceneItems.cpp because typedefs can't be extended yet
 
 /**

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -85,6 +85,8 @@ namespace Utils {
 	const char* GetFilenameFormatting();
 	bool SetFilenameFormatting(const char* filenameFormatting);
 
+	const char* GetCurrentRecordingFilename();
+
 	QString nsToTimestamp(uint64_t ns);
     struct AddSourceData {
         obs_source_t *source;

--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -678,7 +678,10 @@ void WSEvents::OnStreamStopped() {
 
 /**
  * A request to start recording has been issued.
- *
+ * 
+ * Note: `recordingFilename` is not provided in this event because this information
+ * is not available at the time this event is emitted.
+ * 
  * @api events
  * @name RecordingStarting
  * @category recording
@@ -691,37 +694,49 @@ void WSEvents::OnRecordingStarting() {
 /**
  * Recording started successfully.
  *
+ * @return {String} `recordingFilename` Absolute path to the file of the current recording.
+ * 
  * @api events
  * @name RecordingStarted
  * @category recording
  * @since 0.3
  */
 void WSEvents::OnRecordingStarted() {
-	broadcastUpdate("RecordingStarted");
+	OBSDataAutoRelease data = obs_data_create();
+	obs_data_set_string(data, "recordingFilename", Utils::GetCurrentRecordingFilename());
+	broadcastUpdate("RecordingStarted", data);
 }
 
 /**
  * A request to stop recording has been issued.
  *
+ * @return {String} `recordingFilename` Absolute path to the file of the current recording.
+ * 
  * @api events
  * @name RecordingStopping
  * @category recording
  * @since 0.3
  */
 void WSEvents::OnRecordingStopping() {
-	broadcastUpdate("RecordingStopping");
+	OBSDataAutoRelease data = obs_data_create();
+	obs_data_set_string(data, "recordingFilename", Utils::GetCurrentRecordingFilename());
+	broadcastUpdate("RecordingStopping", data);
 }
 
 /**
  * Recording stopped successfully.
  *
+ * @return {String} `recordingFilename` Absolute path to the file of the current recording.
+ * 
  * @api events
  * @name RecordingStopped
  * @category recording
  * @since 0.3
  */
 void WSEvents::OnRecordingStopped() {
-	broadcastUpdate("RecordingStopped");
+	OBSDataAutoRelease data = obs_data_create();
+	obs_data_set_string(data, "recordingFilename", Utils::GetCurrentRecordingFilename());
+	broadcastUpdate("RecordingStopped", data);
 }
 
 /**

--- a/src/WSRequestHandler_Recording.cpp
+++ b/src/WSRequestHandler_Recording.cpp
@@ -21,6 +21,7 @@ RpcResponse ifCanPause(const RpcRequest& request, std::function<RpcResponse()> c
  * @return {boolean} `isRecording` Current recording status.
  * @return {boolean} `isRecordingPaused` Whether the recording is paused or not.
  * @return {String (optional)} `recordTimecode` Time elapsed since recording started (only present if currently recording).
+ * @return {String (optional)} `recordingFilename` Absolute path to the recording file (only present if currently recording).
  *
  * @api requests
  * @name GetRecordingStatus
@@ -37,6 +38,7 @@ RpcResponse WSRequestHandler::GetRecordingStatus(const RpcRequest& request) {
         if (obs_frontend_recording_active()) {
                 QString recordingTimecode = events->getRecordingTimecode();
                 obs_data_set_string(data, "recordTimecode", recordingTimecode.toUtf8().constData());
+				obs_data_set_string(data, "recordingFilename", Utils::GetCurrentRecordingFilename());
         }
 
         return request.success(data);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description

Add a `recordingFilename` field in the response of `GetRecordingStatus` and in the fields of the `RecordingStarted`, `RecordingStopping` and `RecordingStopped` events.

### Motivation and Context

- Being able to know where we're currently recording to.
- Fixes #258

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10 20H2

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Enhancement (modification to a current event/request which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

