### PR TITLE
ci(linux): fix deb package file permissions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,12 +192,17 @@ if(UNIX AND NOT APPLE)
 
 	file(GLOB locale_files data/locale/*.ini)
 
+        set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
+		OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
 	if(${USE_UBUNTU_FIX})
-		install(TARGETS obs-websocket
-			LIBRARY DESTINATION "/usr/lib/obs-plugins")
+		install(TARGETS obs-websocket LIBRARY
+			DESTINATION "/usr/lib/obs-plugins"
+			PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 	endif()
-	install(TARGETS obs-websocket
-		LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
+	install(TARGETS obs-websocket LIBRARY
+		DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins"
+		PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
 	install(FILES ${locale_files}
 		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/obs-websocket/locale")


### PR DESCRIPTION
### Description

Files in the Debian/Ubuntu package are all chmod'ed to 777 (read/write to everyone). This shouldn't be the case.

### Motivation and Context

Fixes #620 

### How Has This Been Tested?

Checking permissions by reading the generate Debian package with 7-Zip on Windows 10.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

