### PR TITLE
Request: add ID support for SetSceneItemRender

### DIFF
--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -403,9 +403,8 @@ RpcResponse WSRequestHandler::ResetSceneItem(const RpcRequest& request) {
 * @since 0.3
 */
 RpcResponse WSRequestHandler::SetSceneItemRender(const RpcRequest& request) {
-	if (!request.hasField("render") ||
-		(!request.hasField("source") && !request.hasField("item"))
-		)
+	bool doesntHaveSourceOrItemParameter = !(request.hasField("source") || request.hasField("item"));
+	if (!request.hasField("render") || doesntHaveSourceOrItemParameter)
 	{
 		return request.failed("missing request parameters");
 	}

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -427,13 +427,11 @@ RpcResponse WSRequestHandler::SetSceneItemRender(const RpcRequest& request) {
 	OBSSceneItemAutoRelease sceneItem;
 
 	if (strlen(itemName)) {
-		OBSDataItemAutoRelease itemField = obs_data_item_byname(request.parameters(), "source");
 		sceneItem = Utils::GetSceneItemFromName(scene, itemName);
 		if (!sceneItem) {
 			return request.failed("specified scene item name doesn't exist");
 		}
 	} else {
-		OBSDataItemAutoRelease itemField = obs_data_item_byname(request.parameters(), "item");
 		sceneItem = Utils::GetSceneItemFromId(scene, itemId);
 		if (!sceneItem) {
 			return request.failed("specified scene item ID doesn't exist");


### PR DESCRIPTION
This helps to address #624 and solves my particular use-case with minimal new `obs-websocket` code

### Description
`item` (an int) can now be passed instead of `source` (string) to `SetSceneItemRender` addressing the situation where the same source has been duplicated in a scene, and hence has the same name.

### How Has This Been Tested?
Verified on my Ubuntu 20.04 laptop - software was built locally using the scripts in the project `CI/` directory

### Types of changes
<!--- - New request/event (non-breaking) -->

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

