### PR TITLE
Requests: SetVolume: allow volumes > 1.0

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -231,7 +231,7 @@ RpcResponse WSRequestHandler::GetSourceTypesList(const RpcRequest& request)
 * @param {boolean (optional)} `useDecibel` Output volume in decibels of attenuation instead of amplitude/mul.
 *
 * @return {String} `name` Source name.
-* @return {double} `volume` Volume of the source. Between `0.0` and `1.0` if using mul, under `0.0` if using dB (since it is attenuating).
+* @return {double} `volume` Volume of the source. Between `0.0` and `20.0` if using mul, under `26.0` if using dB.
 * @return {boolean} `muted` Indicates whether the source is muted.
 *
 * @api requests
@@ -277,7 +277,7 @@ RpcResponse WSRequestHandler::GetVolume(const RpcRequest& request)
 * Set the volume of the specified source. Default request format uses mul, NOT SLIDER PERCENTAGE.
 *
 * @param {String} `source` Source name.
-* @param {double} `volume` Desired volume. Must be between `0.0` and `1.0` for mul, and under 0.0 for dB. Note: OBS will interpret dB values under -100.0 as Inf.
+* @param {double} `volume` Desired volume. Must be between `0.0` and `20.0` for mul, and under 26.0 for dB. OBS will interpret dB values under -100.0 as Inf. Note: The OBS volume sliders only reach a maximum of 1.0mul/0.0dB, however OBS actually supports larger values.
 * @param {boolean (optional)} `useDecibel` Interperet `volume` data as decibels instead of amplitude/mul.
 *
 * @api requests
@@ -296,8 +296,8 @@ RpcResponse WSRequestHandler::SetVolume(const RpcRequest& request)
 	QString sourceName = obs_data_get_string(request.parameters(), "source");
 	float sourceVolume = obs_data_get_double(request.parameters(), "volume");
 
-	bool isNotValidDecibel = (useDecibel && sourceVolume > 0.0);
-	bool isNotValidMul = (!useDecibel && (sourceVolume < 0.0 || sourceVolume > 1.0));
+	bool isNotValidDecibel = (useDecibel && sourceVolume > 26.0);
+	bool isNotValidMul = (!useDecibel && (sourceVolume < 0.0 || sourceVolume > 20.0));
 	if (sourceName.isEmpty() || isNotValidDecibel || isNotValidMul) {
 		return request.failed("invalid request parameters");
 	}


### PR DESCRIPTION
### Description

Allow volumes > 1.0 / > 0dB, which is legal in OBS (you can do this in Advanced Audio Properties). OBS allows up to +26dB gain, so we do the same. This corresponds to approximately 20x linear gain (actually 19.9526231497, but 20 is easier to explain and OBS doesn't care).

### Motivation and Context

This is required to be able to add audio gain to sources that have too low an audio level.

### How Has This Been Tested?

A previous version of this patch was tested with OBS master a few months ago, and used in production. I've rebased this on the current version, which added the decibel mode. I think the change is obvious enough that it does not warrant further testing.

### Types of changes

- Documentation change (a change to documentation pages)
- Enhancement (modification to a current event/request which adds functionality)

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

