### PR TITLE
Add link to obs-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here's a list of available language APIs for obs-websocket :
 - Java 8+: [obs-websocket-java](https://github.com/Twasi/websocket-obs-java) by TwasiNET
 - Golang: [go-obs-websocket](https://github.com/christopher-dG/go-obs-websocket) by Chris de Graaf
 - HTTP API: [obs-websocket-http](https://github.com/IRLToolkit/obs-websocket-http) by tt2468
+- CLI: [obs-cli](https://github.com/leafac/obs-cli) by leafac
 
 I'd like to know what you're building with or for obs-websocket. If you do something in this fashion, feel free to drop a message in `#project-showoff` in the [discord server!](https://discord.gg/WBaSQ3A)
 


### PR DESCRIPTION
### Description

Add a link to obs-cli on the README. obs-cli is a tool to control OBS from the command-line, based on obs-websocket through obs-websocket-js.

### Motivation and Context

This is similar to the obs-websocket-http listed right above it: a wrapper to operate obs-websocket from a different interface (in this case, the command-line interface).

### How Has This Been Tested?

obs-cli is written in Node.js, so it should be cross-platform.
Tested OS(s): macOS

### Types of changes

- Documentation change (a change to documentation pages): A change to the `README`.

### Checklist:

-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate. **I’m not sure what category this commit should be on, so I left it uncategorized.**
-   [x] I have included updates to all appropriate documentation.

