### PR TITLE
General: Add ScenesCollection object

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -476,6 +476,31 @@
     },
     {
       "subheads": [],
+      "typedef": "{Object} `ScenesCollection`",
+      "property": "{String} `sc-name` Name of the scene collection",
+      "properties": [
+        {
+          "type": "String",
+          "name": "sc-name",
+          "description": "Name of the scene collection"
+        }
+      ],
+      "typedefs": [
+        {
+          "type": "Object",
+          "name": "ScenesCollection",
+          "description": ""
+        }
+      ],
+      "name": "",
+      "heading": {
+        "level": 2,
+        "text": ""
+      },
+      "examples": []
+    },
+    {
+      "subheads": [],
       "typedef": "{Object} `Scene`",
       "property": [
         "{String} `name` Name of the currently active scene.",
@@ -8218,24 +8243,16 @@
       {
         "subheads": [],
         "description": "List available scene collections",
-        "return": [
-          "{Array<String>} `scene-collections` Scene collections list",
-          "{String} `scene-collections.*.sc-name` Scene collection name"
-        ],
+        "return": "{Array<ScenesCollection>} `scene-collections` Scene collections list",
         "api": "requests",
         "name": "ListSceneCollections",
         "category": "scene collections",
         "since": "4.0.0",
         "returns": [
           {
-            "type": "Array<String>",
+            "type": "Array<ScenesCollection>",
             "name": "scene-collections",
             "description": "Scene collections list"
-          },
-          {
-            "type": "String",
-            "name": "scene-collections.*.sc-name",
-            "description": "Scene collection name"
           }
         ],
         "names": [

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -49,6 +49,7 @@ You can also refer to any of the client libraries listed on the [README](README.
   * [SceneItemTransform](#sceneitemtransform)
   * [OBSStats](#obsstats)
   * [Output](#output)
+  * [ScenesCollection](#scenescollection)
   * [Scene](#scene)
 - [Events](#events)
   * [Scenes](#scenes)
@@ -344,6 +345,10 @@ These are complex types, such as `Source` and `Scene`, which are used as argumen
 | `totalFrames` | _int_ | Number of frames sent |
 | `droppedFrames` | _int_ | Number of frames dropped |
 | `totalBytes` | _int_ | Total bytes sent |
+## ScenesCollection
+| Name | Type  | Description |
+| ---- | :---: | ------------|
+| `sc-name` | _String_ | Name of the scene collection |
 ## Scene
 | Name | Type  | Description |
 | ---- | :---: | ------------|
@@ -3308,8 +3313,7 @@ _No specified parameters._
 
 | Name | Type  | Description |
 | ---- | :---: | ------------|
-| `scene-collections` | _Array&lt;String&gt;_ | Scene collections list |
-| `scene-collections.*.sc-name` | _String_ | Scene collection name |
+| `scene-collections` | _Array&lt;ScenesCollection&gt;_ | Scene collections list |
 
 
 ---

--- a/src/WSRequestHandler_SceneCollections.cpp
+++ b/src/WSRequestHandler_SceneCollections.cpp
@@ -3,6 +3,11 @@
 #include "WSRequestHandler.h"
 
 /**
+* @typedef {Object} `ScenesCollection`
+* @property {String} `sc-name` Name of the scene collection
+*/
+
+/**
  * Change the active scene collection.
  *
  * @param {String} `sc-name` Name of the desired scene collection.
@@ -59,8 +64,7 @@ RpcResponse WSRequestHandler::GetCurrentSceneCollection(const RpcRequest& reques
 /**
  * List available scene collections
  *
- * @return {Array<String>} `scene-collections` Scene collections list
- * @return {String} `scene-collections.*.sc-name` Scene collection name
+ * @return {Array<ScenesCollection>} `scene-collections` Scene collections list
  *
  * @api requests
  * @name ListSceneCollections


### PR DESCRIPTION
Adds a ScenesCollection object in the protocol definition,
replacing the current Array<String> return  with
Array<ScenesCollection>, keeping it more coherent with
other requests that return objects in the same format.
This will help automated code generation from comment.json
that otherwise would require ad-hoc handling for that specific
request.

Signed-off-by: Valter Minute <valter.minute@gmail.com>

### Description

Added new typedef and changed @return of WSRequestHandler::ListSceneCollections to generate a new object type named ScenesCollection instead of using string.
The changes impacts only generated documentation and comments.json, since the request already returns an array of objects.

### Motivation and Context

This change will make automated code generation of APIs in other languages more straightforward since the description of the API will match its actual return type.
Obviously an array of objects with a single string field can be simplified to a string array, but this will require ad-hoc handling in the API code and can still be done manually on API side.

### How Has This Been Tested?

Rebuilt the documentation following instructions in the README.
Changes are limited to source code comments.

Tested OS(s): 

Ubuntu 18.04

### Types of changes

Bug fix (non-breaking change which fixes an issue) 
Documentation change (a change to documentation pages)

### Checklist:
-   [X] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [X] My code is not on the master branch.
-   [X] The code has been tested.
-   [X] All commit messages are properly formatted and commits squashed where appropriate.
-   [X] I have included updates to all appropriate documentation.

