### PR TITLE
Stop WSServer on OBS exit

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -233,6 +233,7 @@ void WSEvents::FrontendEventHandler(enum obs_frontend_event event, void* private
 		case OBS_FRONTEND_EVENT_EXIT:
 			owner->unhookTransitionPlaybackEvents();
 			owner->OnExit();
+			owner->_srv->stop();
 			break;
 	}
 }


### PR DESCRIPTION
### Description

Stop the `WSServer` when receiving the OBS Exit event.

### Motivation and Context

I have run into crashes on OBS exit due to websocket clients responding to events during teardown. This should fix it by reacting to the exit event and stopping the server.

### How Has This Been Tested?

Tested OS(s): 

 * macOS 10.15.7

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

