### PR TITLE
Config: authentication enabled by default

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -45,7 +45,7 @@ Config::Config() :
 	LockToIPv4(false),
 	DebugEnabled(false),
 	AlertsEnabled(true),
-	AuthRequired(false),
+	AuthRequired(true),
 	Secret(""),
 	Salt(""),
 	SettingsLoaded(false)


### PR DESCRIPTION
### Description

The default per-profile configuration of obs-websocket has authentication enabled

### Motivation and Context

Fixes #424.

### How Has This Been Tested?

Tested OS(s): Windows 10 20H2 x64

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [ ] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [ ] I have included updates to all appropriate documentation.

