### PR TITLE
Requests: Add RefreshBrowserSource

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -120,6 +120,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap{
 	{ "SetAudioMonitorType", &WSRequestHandler::SetAudioMonitorType },
 	{ "GetSourceDefaultSettings", &WSRequestHandler::GetSourceDefaultSettings },
 	{ "TakeSourceScreenshot", &WSRequestHandler::TakeSourceScreenshot },
+	{ "RefreshBrowserSource", &WSRequestHandler::RefreshBrowserSource },
 
 	{ "GetSourceFilters", &WSRequestHandler::GetSourceFilters },
 	{ "GetSourceFilterInfo", &WSRequestHandler::GetSourceFilterInfo },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -137,6 +137,7 @@ class WSRequestHandler {
 		RpcResponse SetAudioMonitorType(const RpcRequest&);
 		RpcResponse GetSourceDefaultSettings(const RpcRequest&);
 		RpcResponse TakeSourceScreenshot(const RpcRequest&);
+		RpcResponse RefreshBrowserSource(const RpcRequest&);
 
 		RpcResponse GetSourceFilters(const RpcRequest&);
 		RpcResponse GetSourceFilterInfo(const RpcRequest&);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Creates a source to programmatically refresh a browser source. I would have made this earlier if I have just spend more time reading the OBS API docs (I'd have known about `obs_property_button_clicked()` so RIP

Fixes #456 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Twas requested.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Ubuntu 20.04

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

