### PR TITLE
Events: Remove sourceSettings from SourceCreated event

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -1080,7 +1080,6 @@ void WSEvents::OnTransitionVideoEnd(void* param, calldata_t* data) {
  * @return {String} `sourceName` Source name
  * @return {String} `sourceType` Source type. Can be "input", "scene", "transition" or "filter".
  * @return {String} `sourceKind` Source kind.
- * @return {Object} `sourceSettings` Source settings
  *
  * @api events
  * @name SourceCreated
@@ -1097,15 +1096,12 @@ void WSEvents::OnSourceCreate(void* param, calldata_t* data) {
 
 	self->connectSourceSignals(source);
 
-	OBSDataAutoRelease sourceSettings = obs_source_get_settings(source);
-
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_string(fields, "sourceType",
 		sourceTypeToString(obs_source_get_type(source))
 	);
 	obs_data_set_string(fields, "sourceKind", obs_source_get_id(source));
-	obs_data_set_obj(fields, "sourceSettings", sourceSettings);
 	self->broadcastUpdate("SourceCreated", fields);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Removes the `sourceSettings` item from the `SourceCreated` event. Decided not to use the deprecation process since the parameter is always `{}` and would never have any users.
Closes #580

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The parameter is useless, as a freshly created source always has default settings, which do not get passed when obs_data_get_json() is called. Users should defer to using `GetSourceDefaultSettings`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Ubuntu 20.04

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

