### PR TITLE
Requests: Add Sleep

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -43,6 +43,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap{
 	{ "TriggerHotkeyByName", &WSRequestHandler::TriggerHotkeyByName },
 	{ "TriggerHotkeyBySequence", &WSRequestHandler::TriggerHotkeyBySequence },
 	{ "ExecuteBatch", &WSRequestHandler::ExecuteBatch },
+	{ "Sleep", &WSRequestHandler::Sleep },
 
 	// Category: Media Control
 	{ "PlayPauseMedia", &WSRequestHandler::PlayPauseMedia },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -61,6 +61,7 @@ class WSRequestHandler {
 		RpcResponse TriggerHotkeyByName(const RpcRequest&);
 		RpcResponse TriggerHotkeyBySequence(const RpcRequest&);
 		RpcResponse ExecuteBatch(const RpcRequest&);
+		RpcResponse Sleep(const RpcRequest&);
 
 		// Category: Media Control
 		RpcResponse PlayPauseMedia(const RpcRequest&);

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -474,3 +474,24 @@ RpcResponse WSRequestHandler::ExecuteBatch(const RpcRequest& request) {
 	obs_data_set_array(response, "results", results);
 	return request.success(response);
 }
+
+/**
+ * Waits for the specified delay. Designed to be used in `ExecuteBatch` operations.
+ *
+ * @param {int} `delayMillis` Delay in milliseconds to wait before continuing.
+ *
+ * @api requests
+ * @name Sleep
+ * @category general
+ * @since unreleased
+ */
+RpcResponse WSRequestHandler::Sleep(const RpcRequest& request) {
+	if (!request.hasField("delayMillis")) {
+		return request.failed("missing request parameters");
+	}
+
+	long long delayMillis = obs_data_get_int(request.parameters(), "delayMillis");
+	std::this_thread::sleep_for(std::chrono::milliseconds(delayMillis));
+
+	return request.success();
+}

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -476,9 +476,9 @@ RpcResponse WSRequestHandler::ExecuteBatch(const RpcRequest& request) {
 }
 
 /**
- * Waits for the specified delay. Designed to be used in `ExecuteBatch` operations.
+ * Waits for the specified duration. Designed to be used in `ExecuteBatch` operations.
  *
- * @param {int} `delayMillis` Delay in milliseconds to wait before continuing.
+ * @param {int} `sleepMillis` Delay in milliseconds to wait before continuing.
  *
  * @api requests
  * @name Sleep
@@ -486,12 +486,12 @@ RpcResponse WSRequestHandler::ExecuteBatch(const RpcRequest& request) {
  * @since unreleased
  */
 RpcResponse WSRequestHandler::Sleep(const RpcRequest& request) {
-	if (!request.hasField("delayMillis")) {
+	if (!request.hasField("sleepMillis")) {
 		return request.failed("missing request parameters");
 	}
 
-	long long delayMillis = obs_data_get_int(request.parameters(), "delayMillis");
-	std::this_thread::sleep_for(std::chrono::milliseconds(delayMillis));
+	long long sleepMillis = obs_data_get_int(request.parameters(), "sleepMillis");
+	std::this_thread::sleep_for(std::chrono::milliseconds(sleepMillis));
 
 	return request.success();
 }


### PR DESCRIPTION
New request to induce delay in the processing of `ExecuteBatch`

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Adds a new request: `Sleep`
This allows you to delay execution, specifically when using it in `ExecuteBatch`. Example uses:
- `StartStreaming`, sleep 5 seconds, then `GetStreamStatus`, in order to verify that stream was started successfully.
- To perform simple animations like setting scene item visibility, with much higher time accuracy than is possible via multiple websocket requests

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Makes `ExecuteBatch` more versatile.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Ubuntu 20.04

Switched between two scenes with a delay of 1000ms between scene switches.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

