### PR TITLE
Requests: Add SetAudioTracks and GetAudioTracks

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -121,6 +121,8 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap{
 	{ "GetSourceTypesList", &WSRequestHandler::GetSourceTypesList },
 	{ "GetVolume", &WSRequestHandler::GetVolume },
 	{ "SetVolume", &WSRequestHandler::SetVolume },
+	{ "SetAudioTracks", &WSRequestHandler::SetAudioTracks },
+	{ "GetAudioTracks", &WSRequestHandler::GetAudioTracks },
 	{ "GetMute", &WSRequestHandler::GetMute },
 	{ "SetMute", &WSRequestHandler::SetMute },
 	{ "ToggleMute", &WSRequestHandler::ToggleMute },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -138,6 +138,8 @@ class WSRequestHandler {
 		RpcResponse GetSourceTypesList(const RpcRequest&);
 		RpcResponse GetVolume(const RpcRequest&);
 		RpcResponse SetVolume(const RpcRequest&);
+		RpcResponse SetAudioTracks(const RpcRequest&);
+		RpcResponse GetAudioTracks(const RpcRequest&);
 		RpcResponse GetMute(const RpcRequest&);
 		RpcResponse SetMute(const RpcRequest&);
 		RpcResponse ToggleMute(const RpcRequest&);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -408,7 +408,7 @@ RpcResponse WSRequestHandler::GetAudioTracks(const RpcRequest& request)
 /**
 * Get the mute status of a specified source.
 *
-* @param {String} `sourceName` Source name.
+* @param {String} `source` Source name.
 *
 * @return {String} `name` Source name.
 * @return {boolean} `muted` Mute status of the source.

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -365,12 +365,12 @@ RpcResponse WSRequestHandler::SetAudioTracks(const RpcRequest& request)
 *
 * @param {String} `source` Source name.
 * 
-* @return {boolean} `mixer1`
-* @return {boolean} `mixer2`
-* @return {boolean} `mixer3`
-* @return {boolean} `mixer4`
-* @return {boolean} `mixer5`
-* @return {boolean} `mixer6`
+* @return {boolean} `track1`
+* @return {boolean} `track2`
+* @return {boolean} `track3`
+* @return {boolean} `track4`
+* @return {boolean} `track5`
+* @return {boolean} `track6`
 *
 * @api requests
 * @name GetTracks
@@ -397,12 +397,12 @@ RpcResponse WSRequestHandler::GetAudioTracks(const RpcRequest& request)
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "name", obs_source_get_name(source));
-	obs_data_set_bool(response, "mixer1", mixers & (1 << 0));
-	obs_data_set_bool(response, "mixer2", mixers & (1 << 1));
-	obs_data_set_bool(response, "mixer3", mixers & (1 << 2));
-	obs_data_set_bool(response, "mixer4", mixers & (1 << 3));
-	obs_data_set_bool(response, "mixer5", mixers & (1 << 4));
-	obs_data_set_bool(response, "mixer6", mixers & (1 << 5));
+	obs_data_set_bool(response, "track1", mixers & (1 << 0));
+	obs_data_set_bool(response, "track2", mixers & (1 << 1));
+	obs_data_set_bool(response, "track3", mixers & (1 << 2));
+	obs_data_set_bool(response, "track4", mixers & (1 << 3));
+	obs_data_set_bool(response, "track5", mixers & (1 << 4));
+	obs_data_set_bool(response, "track6", mixers & (1 << 5));
 	return request.success(response);
 }
 

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -362,7 +362,7 @@ RpcResponse WSRequestHandler::SetAudioTracks(const RpcRequest& request)
 /**
 * Gets whether an audio track is active for a source.
 *
-* @param {String} `source` Source name.
+* @param {String} `sourceName` Source name.
 * 
 * @return {boolean} `track1`
 * @return {boolean} `track2`
@@ -378,11 +378,11 @@ RpcResponse WSRequestHandler::SetAudioTracks(const RpcRequest& request)
 */
 RpcResponse WSRequestHandler::GetAudioTracks(const RpcRequest& request)
 {
-	if (!request.hasField("source")) {
+	if (!request.hasField("sourceName")) {
 		return request.failed("missing request parameters");
 	}
 
-	QString sourceName = obs_data_get_string(request.parameters(), "source");
+	QString sourceName = obs_data_get_string(request.parameters(), "sourceName");
 	if (sourceName.isEmpty()) {
 		return request.failed("invalid request parameters");
 	}

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -364,12 +364,12 @@ RpcResponse WSRequestHandler::SetAudioTracks(const RpcRequest& request)
 *
 * @param {String} `source` Source name.
 * 
-* @return {boolean} `mixer1`
-* @return {boolean} `mixer2`
-* @return {boolean} `mixer3`
-* @return {boolean} `mixer4`
-* @return {boolean} `mixer5`
-* @return {boolean} `mixer6`
+* @return {boolean} `track1`
+* @return {boolean} `track2`
+* @return {boolean} `track3`
+* @return {boolean} `track4`
+* @return {boolean} `track5`
+* @return {boolean} `track6`
 *
 * @api requests
 * @name GetTracks
@@ -396,12 +396,12 @@ RpcResponse WSRequestHandler::GetAudioTracks(const RpcRequest& request)
 
 	OBSDataAutoRelease response = obs_data_create();
 	obs_data_set_string(response, "name", obs_source_get_name(source));
-	obs_data_set_bool(response, "mixer1", mixers & (1 << 0));
-	obs_data_set_bool(response, "mixer2", mixers & (1 << 1));
-	obs_data_set_bool(response, "mixer3", mixers & (1 << 2));
-	obs_data_set_bool(response, "mixer4", mixers & (1 << 3));
-	obs_data_set_bool(response, "mixer5", mixers & (1 << 4));
-	obs_data_set_bool(response, "mixer6", mixers & (1 << 5));
+	obs_data_set_bool(response, "track1", mixers & (1 << 0));
+	obs_data_set_bool(response, "track2", mixers & (1 << 1));
+	obs_data_set_bool(response, "track3", mixers & (1 << 2));
+	obs_data_set_bool(response, "track4", mixers & (1 << 3));
+	obs_data_set_bool(response, "track5", mixers & (1 << 4));
+	obs_data_set_bool(response, "track6", mixers & (1 << 5));
 	return request.success(response);
 }
 

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -408,7 +408,7 @@ RpcResponse WSRequestHandler::GetAudioTracks(const RpcRequest& request)
 /**
 * Get the mute status of a specified source.
 *
-* @param {String} `source` Source name.
+* @param {String} `sourceName` Source name.
 *
 * @return {String} `name` Source name.
 * @return {boolean} `muted` Mute status of the source.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Adds SetAudioTracks and GetAudioTracks which allows toggling the audio output of a source to any of the 6 channels.

### Motivation and Context
Wanted to be able to control which source outputs audio to a track dynamically.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
Windows

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
New request/event (non-breaking)
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

