### PR TITLE
Requests: Add scale.filter to Scene Item Properties

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -52,6 +52,24 @@ obs_bounds_type getBoundsTypeFromName(QString name) {
 	return boundTypeNames.key(name);
 }
 
+const QHash<obs_scale_type, QString> scaleTypeNames = {
+	{ OBS_SCALE_DISABLE, "OBS_SCALE_DISABLE" },
+	{ OBS_SCALE_POINT, "OBS_SCALE_POINT" },
+	{ OBS_SCALE_BICUBIC, "OBS_SCALE_BICUBIC" },
+	{ OBS_SCALE_BILINEAR, "OBS_SCALE_BILINEAR" },
+	{ OBS_SCALE_LANCZOS, "OBS_SCALE_LANCZOS" },
+	{ OBS_SCALE_AREA, "OBS_SCALE_AREA" },
+};
+
+QString getScaleNameFromType(obs_scale_type type) {
+	QString fallback = scaleTypeNames.value(OBS_SCALE_DISABLE);
+	return scaleTypeNames.value(type, fallback);
+}
+
+obs_scale_type getFilterTypeFromName(QString name) {
+	return scaleTypeNames.key(name);
+}
+
 bool Utils::StringInStringList(char** strings, const char* string) {
 	if (!strings) {
 		return false;
@@ -730,6 +748,7 @@ const char* Utils::GetCurrentRecordingFilename()
  * @property {double} `rotation` The clockwise rotation of the scene item in degrees around the point of alignment.
  * @property {double} `scale.x` The x-scale factor of the scene item.
  * @property {double} `scale.y` The y-scale factor of the scene item.
+ * @property {String} `scale.filter` The scale filter of the source. Can be "OBS_SCALE_DISABLE", "OBS_SCALE_POINT", "OBS_SCALE_BICUBIC", "OBS_SCALE_BILINEAR", "OBS_SCALE_LANCZOS" or "OBS_SCALE_AREA".
  * @property {int} `crop.top` The number of pixels cropped off the top of the scene item before scaling.
  * @property {int} `crop.right` The number of pixels cropped off the right of the scene item before scaling.
  * @property {int} `crop.bottom` The number of pixels cropped off the bottom of the scene item before scaling.
@@ -773,12 +792,16 @@ obs_data_t* Utils::GetSceneItemPropertiesData(obs_sceneitem_t* sceneItem) {
 	uint32_t boundsAlignment = obs_sceneitem_get_bounds_alignment(sceneItem);
 	QString boundsTypeName = getBoundsNameFromType(boundsType);
 
+	obs_scale_type scaleFilter = obs_sceneitem_get_scale_filter(sceneItem);
+	QString scaleFilterName = getScaleNameFromType(scaleFilter);
+
 	OBSDataAutoRelease posData = obs_data_create();
 	obs_data_set_double(posData, "x", pos.x);
 	obs_data_set_double(posData, "y", pos.y);
 	obs_data_set_int(posData, "alignment", alignment);
 
 	OBSDataAutoRelease scaleData = obs_data_create();
+	obs_data_set_string(scaleData, "filter", scaleFilterName.toUtf8());
 	obs_data_set_double(scaleData, "x", scale.x);
 	obs_data_set_double(scaleData, "y", scale.y);
 

--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -91,6 +91,7 @@ RpcResponse WSRequestHandler::GetSceneItemList(const RpcRequest& request) {
 * @return {double} `rotation` The clockwise rotation of the item in degrees around the point of alignment.
 * @return {double} `scale.x` The x-scale factor of the source.
 * @return {double} `scale.y` The y-scale factor of the source.
+* @return {String} `scale.filter` The scale filter of the source. Can be "OBS_SCALE_DISABLE", "OBS_SCALE_POINT", "OBS_SCALE_BICUBIC", "OBS_SCALE_BILINEAR", "OBS_SCALE_LANCZOS" or "OBS_SCALE_AREA".
 * @return {int} `crop.top` The number of pixels cropped off the top of the source before scaling.
 * @return {int} `crop.right` The number of pixels cropped off the right of the source before scaling.
 * @return {int} `crop.bottom` The number of pixels cropped off the bottom of the source before scaling.
@@ -156,6 +157,7 @@ RpcResponse WSRequestHandler::GetSceneItemProperties(const RpcRequest& request) 
 * @param {double (optional)} `rotation` The new clockwise rotation of the item in degrees.
 * @param {double (optional)} `scale.x` The new x scale of the item.
 * @param {double (optional)} `scale.y` The new y scale of the item.
+* @param {String (optional)} `scale.filter` The new scale filter of the source. Can be "OBS_SCALE_DISABLE", "OBS_SCALE_POINT", "OBS_SCALE_BICUBIC", "OBS_SCALE_BILINEAR", "OBS_SCALE_LANCZOS" or "OBS_SCALE_AREA".
 * @param {int (optional)} `crop.top` The new amount of pixels cropped off the top of the source before scaling.
 * @param {int (optional)} `crop.bottom` The new amount of pixels cropped off the bottom of the source before scaling.
 * @param {int (optional)} `crop.left` The new amount of pixels cropped off the left of the source before scaling.
@@ -230,11 +232,33 @@ RpcResponse WSRequestHandler::SetSceneItemProperties(const RpcRequest& request) 
 	}
 
 	if (request.hasField("scale")) {
+		OBSDataAutoRelease reqScale = obs_data_get_obj(params, "scale");
+
+		if (obs_data_has_user_value(reqScale, "filter")) {
+			QString newScaleFilter = obs_data_get_string(reqScale, "filter");
+			if (newScaleFilter == "OBS_SCALE_DISABLE") {
+				obs_sceneitem_set_scale_filter(sceneItem, OBS_SCALE_DISABLE);
+			}
+			else if (newScaleFilter == "OBS_SCALE_POINT") {
+				obs_sceneitem_set_scale_filter(sceneItem, OBS_SCALE_POINT);
+			}
+			else if (newScaleFilter == "OBS_SCALE_BICUBIC") {
+				obs_sceneitem_set_scale_filter(sceneItem, OBS_SCALE_BICUBIC);
+			}
+			else if (newScaleFilter == "OBS_SCALE_BILINEAR") {
+				obs_sceneitem_set_scale_filter(sceneItem, OBS_SCALE_BICUBIC);
+			}
+			else if (newScaleFilter == "OBS_SCALE_LANCZOS") {
+				obs_sceneitem_set_scale_filter(sceneItem, OBS_SCALE_LANCZOS);
+			}
+			else if (newScaleFilter == "OBS_SCALE_AREA") {
+				obs_sceneitem_set_scale_filter(sceneItem, OBS_SCALE_AREA);
+			}
+		}
+
 		vec2 oldScale;
 		obs_sceneitem_get_scale(sceneItem, &oldScale);
 		vec2 newScale = oldScale;
-
-		OBSDataAutoRelease reqScale = obs_data_get_obj(params, "scale");
 
 		if (obs_data_has_user_value(reqScale, "x")) {
 			newScale.x = obs_data_get_double(reqScale, "x");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
Adds a filter field to the scale property in both SetSceneItemProperties and GetSceneItemProperties.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
When using things like AddSceneItem to dynamically create scene items, the scale filter will always be set to the default of "Disable". Adding this property means that these items can use a different scale filter if the user wishes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10 x64

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Enhancement (modification to a current event/request which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

