### PR TITLE
Requests: Add GetSourceActive

### DIFF
--- a/src/WSRequestHandler.cpp
+++ b/src/WSRequestHandler.cpp
@@ -124,6 +124,7 @@ const QHash<QString, RpcMethodHandler> WSRequestHandler::messageMap{
 	{ "GetMute", &WSRequestHandler::GetMute },
 	{ "SetMute", &WSRequestHandler::SetMute },
 	{ "ToggleMute", &WSRequestHandler::ToggleMute },
+	{ "GetSourceActive", &WSRequestHandler::GetSourceActive },
 	{ "GetAudioActive", &WSRequestHandler::GetAudioActive },
 	{ "SetSourceName", &WSRequestHandler::SetSourceName },
 	{ "SetSyncOffset", &WSRequestHandler::SetSyncOffset },

--- a/src/WSRequestHandler.h
+++ b/src/WSRequestHandler.h
@@ -141,6 +141,7 @@ class WSRequestHandler {
 		RpcResponse GetMute(const RpcRequest&);
 		RpcResponse SetMute(const RpcRequest&);
 		RpcResponse ToggleMute(const RpcRequest&);
+		RpcResponse GetSourceActive(const RpcRequest&);
 		RpcResponse GetAudioActive(const RpcRequest&);
 		RpcResponse SetSourceName(const RpcRequest&);
 		RpcResponse SetSyncOffset(const RpcRequest&);

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -415,6 +415,40 @@ RpcResponse WSRequestHandler::ToggleMute(const RpcRequest& request)
 }
 
 /**
+* Get the source's active status of a specified source (if it is showing in the final mix).
+*
+* @param {String} `sourceName` Source name.
+*
+* @return {boolean} `sourceActive` Source active status of the source.
+*
+* @api requests
+* @name GetSourceActive
+* @category sources
+* @since unreleased
+*/
+RpcResponse WSRequestHandler::GetSourceActive(const RpcRequest& request)
+{
+	if (!request.hasField("sourceName")) {
+		return request.failed("missing request parameters");
+	}
+
+	QString sourceName = obs_data_get_string(request.parameters(), "sourceName");
+	if (sourceName.isEmpty()) {
+		return request.failed("invalid request parameters");
+	}
+
+	OBSSourceAutoRelease source = obs_get_source_by_name(sourceName.toUtf8());
+	if (!source) {
+		return request.failed("specified source doesn't exist");
+	}
+
+	OBSDataAutoRelease response = obs_data_create();
+	obs_data_set_bool(response, "sourceActive", obs_source_active(source));
+
+	return request.success(response);
+}
+
+/**
 * Get the audio's active status of a specified source.
 *
 * @param {String} `sourceName` Source name.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Add GetSourceActive to know if a source is being showed in the final fix.
(Copy-pasted from GetAudioActive)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
In my context I want to know if a source is shown in the final mix.
This because I use the same sources (microphones) in multiple scenes and I want to know if my voice is audible while streaming / recording.
In my program I have three state for microphones. Active / Muted / Disabled (aka forced muted).
The only method to know if a mic is forced mute for now is to enumerate SceneItems of the current scene (eventually recursively). The method works great but I can't retrieve sources within a group. Other than that, I think it's a more appropriate way to use GetSourceActive.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
Builded with Azure and tested quickly on my Windows 10

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

