### PR TITLE
Requests: Add volumeDb field to SourceVolumeChanged Event

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -1145,6 +1145,7 @@ void WSEvents::OnSourceDestroy(void* param, calldata_t* data) {
  *
  * @return {String} `sourceName` Source name
  * @return {float} `volume` Source volume
+ * @return {float} `volumeDb` Source volume in Decibel
  *
  * @api events
  * @name SourceVolumeChanged
@@ -1164,9 +1165,15 @@ void WSEvents::OnSourceVolumeChange(void* param, calldata_t* data) {
 		return;
 	}
 
+	double volumeDb = obs_mul_to_db(volume);
+	if (volumeDb == -INFINITY) {
+		volumeDb = -100.0;
+	}
+
 	OBSDataAutoRelease fields = obs_data_create();
 	obs_data_set_string(fields, "sourceName", obs_source_get_name(source));
 	obs_data_set_double(fields, "volume", volume);
+	obs_data_set_double(fields, "volumeDb", volumeDb);
 	self->broadcastUpdate("SourceVolumeChanged", fields);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Add volumeDb field to SourceVolumeChanged Event.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Personally I work always with Decibel and when I get a `SourceVolumeChanged` Event, I always have to call `getVolume` (with useDecibel true) in order to get che correct value. This helps me a lot

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Non tested yet. I except to test it when Azure finishes

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
- Enhancement (modification to a current event/request which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [ ] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

