### PR TITLE
Docs: fix typo in output properties

### DIFF
--- a/docs/generated/comments.json
+++ b/docs/generated/comments.json
@@ -366,7 +366,7 @@
         "{boolean} `flags.encoded` Output is encoded",
         "{boolean} `flags.multiTrack` Output uses several audio tracks",
         "{boolean} `flags.service` Output uses a service",
-        "{Object} `settings` Output name",
+        "{Object} `settings` Output settings",
         "{boolean} `active` Output status (active or not)",
         "{boolean} `reconnecting` Output reconnection status (reconnecting or not)",
         "{double} `congestion` Output congestion",
@@ -433,7 +433,7 @@
         {
           "type": "Object",
           "name": "settings",
-          "description": "Output name"
+          "description": "Output settings"
         },
         {
           "type": "boolean",

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -348,7 +348,7 @@ These are complex types, such as `Source` and `Scene`, which are used as argumen
 | `flags.encoded` | _boolean_ | Output is encoded |
 | `flags.multiTrack` | _boolean_ | Output uses several audio tracks |
 | `flags.service` | _boolean_ | Output uses a service |
-| `settings` | _Object_ | Output name |
+| `settings` | _Object_ | Output settings |
 | `active` | _boolean_ | Output status (active or not) |
 | `reconnecting` | _boolean_ | Output reconnection status (reconnecting or not) |
 | `congestion` | _double_ | Output congestion |
@@ -4523,4 +4523,3 @@ If your code needs to perform multiple successive T-Bar moves (e.g. : in an anim
 _No additional response items._
 
 ---
-

--- a/src/WSRequestHandler_Outputs.cpp
+++ b/src/WSRequestHandler_Outputs.cpp
@@ -15,7 +15,7 @@
 * @property {boolean} `flags.encoded` Output is encoded
 * @property {boolean} `flags.multiTrack` Output uses several audio tracks
 * @property {boolean} `flags.service` Output uses a service
-* @property {Object} `settings` Output name
+* @property {Object} `settings` Output settings
 * @property {boolean} `active` Output status (active or not)
 * @property {boolean} `reconnecting` Output reconnection status (reconnecting or not)
 * @property {double} `congestion` Output congestion


### PR DESCRIPTION
### Description
Fix a small typo in the documentation for the `Output` typedef.

### Motivation and Context
Fixes #717

### How Has This Been Tested?
N/A

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Documentation change (a change to documentation pages)

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

