### PR TITLE
Fixed url to refer to the correct part of the readme

### DIFF
--- a/docs/partials/introduction.md
+++ b/docs/partials/introduction.md
@@ -35,4 +35,4 @@ auth_response_hash = binary_sha256(auth_response_string)
 auth_response = base64_encode(auth_response_hash)
 ```
 
-You can also refer to any of the client libraries listed on the [README](README.md) for examples of how to authenticate.
+You can also refer to any of the [client libraries](https://github.com/Palakis/obs-websocket#for-developers) listed on the README for examples of how to authenticate.


### PR DESCRIPTION
### Description
Fixed URL in introduction.md to correct part of README. (Previous link was dead)

### Motivation and Context
Documentation fix for dead link

### How Has This Been Tested?
Clicked the link :) 

### Types of changes
- Documentation change (a change to documentation pages)

### Checklist:
-   [X] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [X] My code is not on the master branch.
-   [X] The code has been tested.
-   [X] All commit messages are properly formatted and commits squashed where appropriate.
-   [X] I have included updates to all appropriate documentation.

