### PR TITLE
Requests: Fix leak in SetSceneTransitionOverride

### DIFF
--- a/src/WSRequestHandler_Scenes.cpp
+++ b/src/WSRequestHandler_Scenes.cpp
@@ -204,7 +204,8 @@ RpcResponse WSRequestHandler::SetSceneTransitionOverride(const RpcRequest& reque
 	}
 
 	QString transitionName = obs_data_get_string(request.parameters(), "transitionName");
-	if (!Utils::GetTransitionFromName(transitionName)) {
+	OBSSourceAutoRelease transition = Utils::GetTransitionFromName(transitionName);
+	if (!transition) {
 		return request.failed("requested transition does not exist");
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Wrap the response of `Utils::GetTransitionFromName` into a `OBSSourceAutoRelease` so that the returned and ref-count increased value is properly decreased and potentially freed after the value moves out of scope.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
After some own investigation for my crashes as described in #645 and on Discord I found out that the `Utils::GetTransitionFromName` internally adds a reference count on the returned source (if one is found).
Therefore, if a source was found the reference count is never decreased and causes a crash at shutdown time. I would have just expected a memory leak but it seems to put internals of OBS in a weird state (in my case it made the vlc video source crash).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested by running sending the `SetSceneTransitionOverride` command through my [Rust client library](https://github.com/dnaka91/obws).

Tested OS(s): MacOS

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

