### PR TITLE
Requests: Fix leak in ReleaseTBar, SetTBarPosition

### DIFF
--- a/src/WSRequestHandler_Transitions.cpp
+++ b/src/WSRequestHandler_Transitions.cpp
@@ -144,9 +144,9 @@ RpcResponse WSRequestHandler::GetTransitionPosition(const RpcRequest& request) {
  * Get the current settings of a transition
  *
  * @param {String} `transitionName` Transition name
- * 
+ *
  * @return {Object} `transitionSettings` Current transition settings
- * 
+ *
  * @api requests
  * @name GetTransitionSettings
  * @category transitions
@@ -175,9 +175,9 @@ RpcResponse WSRequestHandler::GetTransitionSettings(const RpcRequest& request) {
  *
  * @param {String} `transitionName` Transition name
  * @param {Object} `transitionSettings` Transition settings (they can be partial)
- * 
+ *
  * @return {Object} `transitionSettings` Updated transition settings
- * 
+ *
  * @api requests
  * @name SetTransitionSettings
  * @category transitions
@@ -219,7 +219,8 @@ RpcResponse WSRequestHandler::ReleaseTBar(const RpcRequest& request) {
 		return request.failed("studio mode not enabled");
 	}
 
-	if (obs_transition_fixed(obs_frontend_get_current_transition())) {
+    OBSSourceAutoRelease transition = obs_frontend_get_current_transition();
+	if (obs_transition_fixed(transition)) {
 		return request.failed("current transition doesn't support t-bar control");
 	}
 
@@ -231,7 +232,7 @@ RpcResponse WSRequestHandler::ReleaseTBar(const RpcRequest& request) {
 /**
  * Set the manual position of the T-Bar (in Studio Mode) to the specified value. Will return an error if OBS is not in studio mode
  * or if the current transition doesn't support T-Bar control.
- * 
+ *
  * If your code needs to perform multiple successive T-Bar moves (e.g. : in an animation, or in response to a user moving a T-Bar control in your User Interface), set `release` to false and call `ReleaseTBar` later once the animation/interaction is over.
  *
  * @param {double} `position` T-Bar position. This value must be between 0.0 and 1.0.
@@ -247,7 +248,8 @@ RpcResponse WSRequestHandler::SetTBarPosition(const RpcRequest& request) {
 		return request.failed("studio mode not enabled");
 	}
 
-	if (obs_transition_fixed(obs_frontend_get_current_transition())) {
+    OBSSourceAutoRelease transition = obs_frontend_get_current_transition();
+	if (obs_transition_fixed(transition)) {
 		return request.failed("current transition doesn't support t-bar control");
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Put the response of `obs_frontend_get_current_transition` into a `OBSSourceAutoRelease` to properly reduce the ref count when it moves out of scope and potentially release the memory.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The memory leak caused the same crashes as to what #761 solves. Somehow the memory leak causes a vlc source and/or browser source to crash.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Ran the related commands with the integration tests of [obws](https://github.com/dnaka91/obws) and confirmed that no crash happened when shutting down OBS.

Tested OS(s): MacOS

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

