### PR TITLE
Requests: Fix spelling mistake of "does not"

### DIFF
--- a/src/WSRequestHandler_SceneItems.cpp
+++ b/src/WSRequestHandler_SceneItems.cpp
@@ -31,7 +31,7 @@ RpcResponse WSRequestHandler::GetSceneItemList(const RpcRequest& request) {
 
 	OBSScene scene = obs_scene_from_source(sceneSource);
 	if (!scene) {
-		return request.failed("requested scene is invalid or doesnt exist");
+		return request.failed("requested scene is invalid or does not exist");
 	}
 
 	OBSDataArrayAutoRelease sceneItemArray = obs_data_array_create();
@@ -670,7 +670,7 @@ RpcResponse WSRequestHandler::AddSceneItem(const RpcRequest& request) {
 	OBSSourceAutoRelease sceneSource = obs_get_source_by_name(sceneName);
 	OBSScene scene = obs_scene_from_source(sceneSource);
 	if (!scene) {
-		return request.failed("requested scene is invalid or doesnt exist");
+		return request.failed("requested scene is invalid or does not exist");
 	}
 
 	const char* sourceName = obs_data_get_string(request.parameters(), "sourceName");

--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -55,7 +55,7 @@ RpcResponse WSRequestHandler::CreateSource(const RpcRequest& request)
 	OBSSourceAutoRelease sceneSource = obs_get_source_by_name(sceneName);
 	OBSScene scene = obs_scene_from_source(sceneSource);
 	if (!scene) {
-		return request.failed("requested scene is invalid or doesnt exist");
+		return request.failed("requested scene is invalid or does not exist");
 	}
 
 	OBSDataAutoRelease sourceSettings = nullptr;


### PR DESCRIPTION
### Description

Using "doesnt" is incorrect: Either use "doesn't" or "does not".

Since the error messages are short, write out "does not".

The master branch is not affected.

### How Has This Been Tested?
Tested OS(s): Ubuntu 21.04

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [ ] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [ ] I have included updates to all appropriate documentation.

