### PR TITLE
Protocol: Fix double free of obs_data_t*

### DIFF
--- a/src/protocol/OBSRemoteProtocol.cpp
+++ b/src/protocol/OBSRemoteProtocol.cpp
@@ -132,7 +132,7 @@ obs_data_t* OBSRemoteProtocol::buildResponse(const char* messageId, const char* 
 	return response;
 }
 
-std::string OBSRemoteProtocol::jsonDataToString(OBSDataAutoRelease data)
+std::string OBSRemoteProtocol::jsonDataToString(obs_data_t *data)
 {
 	std::string responseString = obs_data_get_json(data);
 	return responseString;

--- a/src/protocol/OBSRemoteProtocol.h
+++ b/src/protocol/OBSRemoteProtocol.h
@@ -37,5 +37,5 @@ private:
 	static obs_data_t* successResponse(const char* messageId, obs_data_t* fields = nullptr);
 	static obs_data_t* errorResponse(const char* messageId, const char* errorMessage, obs_data_t* additionalFields = nullptr);
 	static obs_data_t* buildResponse(const char* messageId, const char*, obs_data_t* fields = nullptr);
-	static std::string jsonDataToString(OBSDataAutoRelease data);
+	static std::string jsonDataToString(obs_data_t *data);
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Heap corruption fix. Fixes double release on obs_data_t*.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
I was debugging a crash and this kept making windbg break execution.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10 20H2

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

