### PR TITLE
Update protocol.md to update Set/GetAudioTracks (was Get/SetTracks which doesn't match source)

### DIFF
--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -164,8 +164,8 @@ You can also refer to any of the [client libraries](https://github.com/Palakis/o
     + [GetSourceTypesList](#getsourcetypeslist)
     + [GetVolume](#getvolume)
     + [SetVolume](#setvolume)
-    + [SetTracks](#settracks)
-    + [GetTracks](#gettracks)
+    + [SetAudioTracks](#setaudiotracks)
+    + [GetAudioTracks](#getaudiotracks)
     + [GetMute](#getmute)
     + [SetMute](#setmute)
     + [ToggleMute](#togglemute)
@@ -2213,7 +2213,7 @@ _No additional response items._
 
 ---
 
-### SetTracks
+### SetAudioTracks
 
 
 - Added in v4.9.1
@@ -2235,7 +2235,7 @@ _No additional response items._
 
 ---
 
-### GetTracks
+### GetAudioTracks
 
 
 - Added in v4.9.1


### PR DESCRIPTION
### Description
This pull fixes GetAudioTrack and SetAudioTrack in protocol.md, nothing else.

### Motivation and Context
Erroneously, the protocol lists GetTracks and SetTracks where it should read GetAudioTracks and SetAudioTracks. Described also in #789 

### How Has This Been Tested?
Protocol docs only change, no testing done (other than verifying Get/SetAudioTracks works)

### Types of changes
 - Documentation change (a change to documentation pages)

### Checklist:
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

