### PR TITLE
WSRequestHandler_Sources: fix comment name for Set/GetAudioTrack

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -323,7 +323,7 @@ RpcResponse WSRequestHandler::SetVolume(const RpcRequest& request)
 * @param {boolean} `active` Whether audio track is active or not.
 *
 * @api requests
-* @name SetTracks
+* @name SetAudioTracks
 * @category sources
 * @since 4.9.1
 */
@@ -372,7 +372,7 @@ RpcResponse WSRequestHandler::SetAudioTracks(const RpcRequest& request)
 * @return {boolean} `track6`
 *
 * @api requests
-* @name GetTracks
+* @name GetAudioTracks
 * @category sources
 * @since 4.9.1
 */


### PR DESCRIPTION
### Description
Functions were named SetTracks and GetTracks rather than SetAudioTracks and GetAudioTracks as in the actual code, so this mismatch gets picked up by the protocol docs (but not anymore).

### Motivation and Context
Docs were incorrectly listing GetTracks and SetTracks, requests that don't work.
Fixes #789 

### How Has This Been Tested?
Only comment changes, no further compiling or testing done.

### Types of changes
 - Documentation change (a change to documentation pages)

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [ ] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

