### PR TITLE
Docs: Add another Go client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Here's a list of available language APIs for obs-websocket :
 - Python 3.6+ with asyncio: [simpleobsws](https://github.com/IRLToolkit/simpleobsws) by tt2468
 - Java 8+: [obs-websocket-java](https://github.com/Twasi/websocket-obs-java) by TwasiNET
 - Java 11+: [obs-java-client](https://github.com/harm27/obs-java-client) by harm27
-- Golang: [go-obs-websocket](https://github.com/christopher-dG/go-obs-websocket) by Chris de Graaf
+- Go: [go-obs-websocket](https://github.com/christopher-dG/go-obs-websocket) by Chris de Graaf
+- Go: [goobs](https://github.com/andreykaipov/goobs) by Andrey Kaipov
 - Rust: [obws](https://github.com/dnaka91/obws) by dnaka91
 - Dart: [obs_websocket](https://pub.dev/packages/obs_websocket) by faithoflifedev
 - HTTP API: [obs-websocket-http](https://github.com/IRLToolkit/obs-websocket-http) by tt2468


### PR DESCRIPTION
### Description
The existing Go client doesn't seem to be supported anymore so I made my own at https://github.com/andreykaipov/goobs for the v4.9.1 protocol, and I plan on updating it when v5 is ready! 😄

### Types of changes
Documentation change

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

