### PR TITLE
Requests: Fix wrong validation in ValidateBasic

### DIFF
--- a/src/requesthandler/rpc/Request.cpp
+++ b/src/requesthandler/rpc/Request.cpp
@@ -24,7 +24,7 @@ const bool Request::Contains(const std::string keyName) const
 
 const bool Request::ValidateBasic(const std::string keyName, RequestStatus::RequestStatus &statusCode, std::string &comment) const
 {
-	if (HasRequestData) {
+	if (!HasRequestData) {
 		statusCode = RequestStatus::MissingRequestData;
 		comment = "Your request data is missing or invalid (non-object)";
 		return false;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes. -->
Currently the `Request::ValidateBasic` function returns an error about missing request data whenever it HAS data. Instead it shoudl return the error when it's missing data.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Many requests failed during testing changes in my client lib and I found this bool check being wrong.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

Tested most of the available API requests as part of integration tests for the Rust client library.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-  [ ] My code is not on the master branch.
-  [x] The code has been tested.
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] I have included updates to all appropriate documentation.

