### PR TITLE
Server: remove QtConcurrent dependency

### DIFF
--- a/src/WSServer.cpp
+++ b/src/WSServer.cpp
@@ -23,7 +23,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QtCore/QByteArray>
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QMessageBox>
-#include <QtConcurrent/QtConcurrent>
 #include <obs-frontend-api.h>
 #include <util/platform.h>
 
@@ -207,7 +206,7 @@ void WSServer::onMessage(connection_hdl hdl, server::message_ptr message)
 		return;
 	}
 
-	QtConcurrent::run(&_threadPool, [=]() {
+	_threadPool.start(QRunnable::create([=]() {
 		std::string payload = message->get_payload();
 
 		QMutexLocker locker(&_clMutex);
@@ -234,7 +233,7 @@ void WSServer::onMessage(connection_hdl hdl, server::message_ptr message)
 			blog(LOG_INFO, "server(response): send failed: %s",
 				errorCodeMessage.c_str());
 		}
-	});
+	}));
 }
 
 void WSServer::onClose(connection_hdl hdl)


### PR DESCRIPTION
### Description

Replaces `QtConcurrent::run()` with `QThreadPool::start(QRunnable::create())` (available in Qt 5.15+)

### Motivation and Context

`QtConcurrent` isn't included with [OBS's build of Qt 5.15.2 for Windows](https://cdn-fastly.obsproject.com/downloads/Qt_5.15.2.7z) mentioned [in their build instructions](https://obsproject.com/wiki/install-instructions#windows-build-directions). Seeing as the only thing this does with `QtConcurrent` is spawn a worker in a `QThreadPool`, using the lower level APIs is much simpler and should reduce binary size.

There are a couple of more changes needed to make this plugin build _cleanly_ with OBS's version of Qt, and to get things working with the CI setup, which will be addressed later on -- those changes are much more invasive.

### How Has This Been Tested?

Tested OS(s): builds and runs fine on Win64 against OBS 27.1.0 commit ef0540c0d

### Types of changes

- Code cleanup

### Checklist:

-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

