### PR TITLE
Events: fix compiler warning for implicit cast

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -1355,10 +1355,10 @@ void WSEvents::OnSourceAudioMixersChanged(void* param, calldata_t* data) {
 	}
 
 	OBSDataArrayAutoRelease mixers = obs_data_array_create();
-	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+	for (long long i = 0; i < MAX_AUDIO_MIXES; i++) {
 		OBSDataAutoRelease item = obs_data_create();
 		obs_data_set_int(item, "id", i + 1);
-		obs_data_set_bool(item, "enabled", (1 << i) & audioMixers);
+		obs_data_set_bool(item, "enabled", (audioMixers >> i) & 1);
 		obs_data_array_push_back(mixers, item);
 	}
 


### PR DESCRIPTION
### Description

Fixes a compiler warning for implicit `int32` to `int64` conversion:

```
##[warning]src\WSEvents.cpp(1361,60): Warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
```

### Motivation and Context

### How Has This Been Tested?

Tested OS(s): win64

### Types of changes

- Code cleanup

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

