### PR TITLE
Config: Use QRandomGenerator, QByteArray for password functions

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -20,7 +20,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <obs-frontend-api.h>
 #include <util/config-file.h>
-#include <QtCore/QString>
+#include <QtCore/QByteArray>
+#include <QtCore/QRandomGenerator>
 #include <QtCore/QSharedPointer>
 
 class Config {
@@ -34,11 +35,11 @@ class Config {
 
 		void MigrateFromGlobalSettings();
 
-		void SetPassword(QString password);
-		bool CheckAuth(QString userChallenge);
-		QString GenerateSalt();
-		static QString GenerateSecret(
-				QString password, QString salt);
+		void SetPassword(QByteArray password);
+		bool CheckAuth(QByteArray userChallenge);
+		QByteArray GenerateSalt();
+		static QByteArray GenerateSecret(
+				QByteArray password, QByteArray salt);
 
 		bool ServerEnabled;
 		uint64_t ServerPort;
@@ -48,12 +49,13 @@ class Config {
 		bool AlertsEnabled;
 
 		bool AuthRequired;
-		QString Secret;
-		QString Salt;
-		QString SessionChallenge;
+		QByteArray Secret;
+		QByteArray Salt;
+		QByteArray SessionChallenge;
 		bool SettingsLoaded;
 
 	private:
 		static void OnFrontendEvent(enum obs_frontend_event event, void* param);
 		static void FirstRunPasswordSetup();
+		QRandomGenerator _rng;
 };

--- a/src/WSRequestHandler_General.cpp
+++ b/src/WSRequestHandler_General.cpp
@@ -122,10 +122,8 @@ RpcResponse WSRequestHandler::GetAuthRequired(const RpcRequest& request) {
 	obs_data_set_bool(data, "authRequired", authRequired);
 
 	if (authRequired) {
-		obs_data_set_string(data, "challenge",
-			config->SessionChallenge.toUtf8());
-		obs_data_set_string(data, "salt",
-			config->Salt.toUtf8());
+		obs_data_set_string(data, "challenge", config->SessionChallenge);
+		obs_data_set_string(data, "salt", config->Salt);
 	}
 
 	return request.success(data);
@@ -150,7 +148,7 @@ RpcResponse WSRequestHandler::Authenticate(const RpcRequest& request) {
 		return request.failed("already authenticated");
 	}
 
-	QString auth = obs_data_get_string(request.parameters(), "auth");
+	QByteArray auth = obs_data_get_string(request.parameters(), "auth");
 	if (auth.isEmpty()) {
 		return request.failed("auth not specified!");
 	}

--- a/src/forms/settings-dialog.cpp
+++ b/src/forms/settings-dialog.cpp
@@ -108,7 +108,7 @@ void SettingsDialog::FormAccepted() {
 
 	if (ui->authRequired->isChecked()) {
 		if (ui->password->text() != CHANGE_ME) {
-			conf->SetPassword(ui->password->text());
+			conf->SetPassword(ui->password->text().toUtf8());
 		}
 
 		if (!conf->Secret.isEmpty())


### PR DESCRIPTION
### Description

* `qsrand` and `qrand` are deprecated, replace them with `QRandomGenerator::securelySeeded()`, which is more appropriate for crypto operations.

* Use `QByteArray` rather than `QString` for password functionality.

* Use `QCryptographicHash::addData` to avoid copying strings.

* Use `GenerateSecret` in `CheckAuth`, because they do the same thing anyway.

### Motivation and Context

```
##[warning]src\Config.cpp(59,2): Warning C4996: 'qsrand': use QRandomGenerator instead
##[warning]src\Config.cpp(209,28): Warning C4996: 'qrand': use QRandomGenerator instead
```

### How Has This Been Tested?

Tested OS(s): win64

### Types of changes

- Bug fix
- Code cleanup

### Checklist:

-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

