### PR TITLE
requesthandler: Add `Compare` and `Assert`

### DIFF
--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -33,6 +33,8 @@ const std::unordered_map<std::string, RequestMethodHandler> RequestHandler::_han
 	{"TriggerHotkeyByName", &RequestHandler::TriggerHotkeyByName},
 	{"TriggerHotkeyByKeySequence", &RequestHandler::TriggerHotkeyByKeySequence},
 	{"Sleep", &RequestHandler::Sleep},
+	{"Compare", &RequestHandler::Compare},
+	{"Assert", &RequestHandler::Assert},
 
 	// Config
 	{"GetPersistentData", &RequestHandler::GetPersistentData},

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -52,6 +52,8 @@ private:
 	RequestResult TriggerHotkeyByName(const Request &);
 	RequestResult TriggerHotkeyByKeySequence(const Request &);
 	RequestResult Sleep(const Request &);
+	RequestResult Compare(const Request &);
+	RequestResult Assert(const Request &);
 
 	// Config
 	RequestResult GetPersistentData(const Request &);

--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -332,7 +332,9 @@ RequestResult RequestHandler::TriggerHotkeyByKeySequence(const Request &request)
 }
 
 /**
- * Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
+ * Sleeps for a time duration or number of frames.
+ *
+ * Note: Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
  *
  * @requestField ?sleepMillis | Number | Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode) | >= 0, <= 50000
  * @requestField ?sleepFrames | Number | Number of frames to sleep for (if `SERIAL_FRAME` mode) | >= 0, <= 10000
@@ -364,4 +366,64 @@ RequestResult RequestHandler::Sleep(const Request &request)
 	} else {
 		return RequestResult::Error(RequestStatus::UnsupportedRequestBatchExecutionType);
 	}
+}
+
+/**
+ * Compares the values of the two request fields, `left` and `right`.
+ *
+ * Note: Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
+ *
+ * @requestField left  | Any | First request batch variable in comparison
+ * @requestField right | Any | Second request batch variable in comparison
+ *
+ * @responseField result | Boolean | Whether the comparison is equal
+ *
+ * @requestType Compare
+ * @complexity 4
+ * @rpcVersion -1
+ * @initialVersion 5.4.0
+ * @category general
+ * @api requests
+ */
+RequestResult RequestHandler::Compare(const Request &request)
+{
+	if (!request.RequestData.contains("left") || !request.RequestData.contains("right"))
+		return RequestResult::Error(RequestStatus::MissingRequestField, "One or more sides of the comparison are missing.");
+
+	bool result = request.RequestData["left"] == request.RequestData["right"];
+
+	json responseData;
+	responseData["result"] = result;
+	return RequestResult::Success(responseData);
+}
+
+
+/**
+ * Returns an error if the value of `check` is not `true`.
+ *
+ * This can be useful to interrupt a request batch from proceeding if an assumed state does not match real-world state.
+ *
+ * Note: Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
+ *
+ * @requestField check | Boolean | Value to assert to be true
+ *
+ * @requestType Assert
+ * @complexity 4
+ * @rpcVersion -1
+ * @initialVersion 5.4.0
+ * @category general
+ * @api requests
+ */
+RequestResult RequestHandler::Assert(const Request &request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	if (!request.ValidateBoolean("check", statusCode, comment))
+		return RequestResult::Error(statusCode, comment);
+
+	bool check = request.RequestData["check"];
+	if (!check)
+		return RequestResult::Error(RequestStatus::AssertFailed, "Assertion failed.");
+
+	return RequestResult::Success();
 }

--- a/src/requesthandler/types/RequestStatus.h
+++ b/src/requesthandler/types/RequestStatus.h
@@ -415,5 +415,16 @@ namespace RequestStatus {
 		* @api enums
 		*/
 		CannotAct = 703,
+		/**
+		 * Assertion failed.
+		 *
+		 * @enumIdentifier AssertFailed
+		 * @enumValue 704
+		 * @enumType RequestStatus
+		 * @rpcVersion -1
+		 * @initialVersion 5.4.0
+		 * @api enums
+		 */
+		AssertFailed = 704,
 	};
 }


### PR DESCRIPTION
### Description
Usable for performing some basic logic functions. Not feature-complete.

### Motivation and Context
Request batches have limited functionality due to lack of logic and variable mutations. This attempts to introduce a bit of this functionality.

Alternative suggested implementation: https://github.com/obsproject/obs-websocket/issues/1112

### How Has This Been Tested?
Tested OS(s): Ubuntu 22.04

### Types of changes
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
