### PR TITLE
Readme: Add OBSWebSocketAHK to Client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Here's a list of available language APIs for obs-websocket:
 - Go: [goobs](https://github.com/andreykaipov/goobs) by andreykaipov
 - Dart/Flutter (can target all supported platforms): [obs_websocket](https://github.com/faithoflifedev/obs_websocket) by faithoflifedev
 - Java: [obs-websocket-java](https://github.com/obs-websocket-community-projects/obs-websocket-java) by OBS Websocket Community
+- AutoHotKey: [OBSWebSocketAHK](https://github.com/5ony/OBSWebSocketAHK) by 5ony
 
 The 5.x server is a typical WebSocket server running by default on port 4455 (the port number can be changed in the Settings dialog under `Tools`).
 The protocol we use is documented in [PROTOCOL.md](docs/generated/protocol.md).


### PR DESCRIPTION
### Description

Add OBSWebSocketAHK to Client libraries in Readme

### Motivation and Context

OBSWebSocketAHK library makes it possible to control OBS via WebSocket from AutoHotKey, which is a free, open-source macro-creation and automation software for Windows.

### How Has This Been Tested?

This is a readme change, no need for testing. (However, OBSWebSocketAHK was tested daily by me and their users.)

### Types of changes
Documentation change (a change to documentation pages)

### Checklist:

-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
