### PR TITLE
websocketserver: Allow the user to bind to a specific address 

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -32,9 +32,11 @@ struct Config {
 
 	std::atomic<bool> PortOverridden = false;
 	std::atomic<bool> PasswordOverridden = false;
+	std::atomic<bool> HostOverridden = false;
 
 	std::atomic<bool> FirstLoad = true;
 	std::atomic<bool> ServerEnabled = false;
+	std::string ServerHost;
 	std::atomic<uint16_t> ServerPort = 4455;
 	std::atomic<bool> Ipv4Only = false;
 	std::atomic<bool> DebugEnabled = false;

--- a/src/forms/ConnectInfo.cpp
+++ b/src/forms/ConnectInfo.cpp
@@ -56,6 +56,8 @@ void ConnectInfo::RefreshData()
 	}
 
 	QString serverIp = QString::fromStdString(Utils::Platform::GetLocalAddress());
+	if (conf->ServerHost != "")
+		serverIp = QString::fromStdString(conf->ServerHost);
 	ui->serverIpLineEdit->setText(serverIp);
 
 	QString serverPort = QString::number(conf->ServerPort);

--- a/src/websocketserver/WebSocketServer.cpp
+++ b/src/websocketserver/WebSocketServer.cpp
@@ -100,7 +100,10 @@ void WebSocketServer::Start()
 	_server.reset();
 
 	websocketpp::lib::error_code errorCode;
-	if (conf->Ipv4Only) {
+	if (conf->ServerHost != "") {
+		blog(LOG_INFO, "[WebSocketServer::Start] Locked to %s", conf->ServerHost);
+		_server.listen(conf->ServerHost, std::to_string(conf->ServerPort), errorCode);
+	} else if (conf->Ipv4Only) {
 		blog(LOG_INFO, "[WebSocketServer::Start] Locked to IPv4 bindings");
 		_server.listen(websocketpp::lib::asio::ip::tcp::v4(), conf->ServerPort, errorCode);
 	} else {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
This PR adds a config variable and command line argument for binding the websocket server to a specific address, rather than blindly listening on all interfaces.
This PR does not currently add a GUI element to configure this.

By default, OBS will continue listening on all addresses, this just adds the option to reduce the exposure for users who want or need it (changing the default appears to be the main reason 1cd12c10237a388288250820227d05800f40f064 was reverted).

I have chosen to allow binding of a specific address instead of a "localhost only" flag, as it's more flexible for users with multiple network adaptors.

No UI changes just yet, because I'm not sure how to best expose it in a UI, and feel like the users who want/need it are probably comfortable with hand-editing the config or using the CLI argument.  


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
I am trying to use OSB websockets in an environment where listening on all addresses is a problem.  This allows me to bind OBS to only one network adaptor.
This PR also addresses the security concerns of #907, allowing the user to bind to `127.0.0.1` or `::1`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Modified config file, tried connecting to the socket from local machine and remote machine.
Reset config file, then repeated test with command line argument.
Also conducted test without any config changes to ensure default was still `0.0.0.0`

Tested OS(s): 
Windows 10, Windows 11

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- New request/event (non-breaking)
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [ ] I have included updates to all appropriate documentation.
