### PR TITLE
HandleSceneItemTransformChanged Event handler fix

### DIFF
--- a/src/eventhandler/EventHandler.cpp
+++ b/src/eventhandler/EventHandler.cpp
@@ -87,8 +87,6 @@ void EventHandler::ProcessSubscriptionChange(bool type, uint64_t eventSubscripti
 			_inputActiveStateChangedRef++;
 		if ((eventSubscriptions & EventSubscription::InputShowStateChanged) != 0)
 			_inputShowStateChangedRef++;
-		if ((eventSubscriptions & EventSubscription::SceneItemTransformChanged) != 0)
-			_sceneItemTransformChangedRef++;
 	} else {
 		if ((eventSubscriptions & EventSubscription::InputVolumeMeters) != 0) {
 			if (_inputVolumeMetersRef.fetch_sub(1) == 1)
@@ -98,8 +96,6 @@ void EventHandler::ProcessSubscriptionChange(bool type, uint64_t eventSubscripti
 			_inputActiveStateChangedRef--;
 		if ((eventSubscriptions & EventSubscription::InputShowStateChanged) != 0)
 			_inputShowStateChangedRef--;
-		if ((eventSubscriptions & EventSubscription::SceneItemTransformChanged) != 0)
-			_sceneItemTransformChangedRef--;
 	}
 }
 

--- a/src/eventhandler/EventHandler.h
+++ b/src/eventhandler/EventHandler.h
@@ -58,7 +58,6 @@ private:
 	std::atomic<uint64_t> _inputVolumeMetersRef = 0;
 	std::atomic<uint64_t> _inputActiveStateChangedRef = 0;
 	std::atomic<uint64_t> _inputShowStateChangedRef = 0;
-	std::atomic<uint64_t> _sceneItemTransformChangedRef = 0;
 
 	void ConnectSourceSignals(obs_source_t *source);
 	void DisconnectSourceSignals(obs_source_t *source);

--- a/src/eventhandler/EventHandler_SceneItems.cpp
+++ b/src/eventhandler/EventHandler_SceneItems.cpp
@@ -272,7 +272,7 @@ void EventHandler::HandleSceneItemSelected(void *param, calldata_t *data)
  * @dataField sceneItemTransform | Object | New transform/crop info of the scene item
  *
  * @eventType SceneItemTransformChanged
- * @eventSubscription SceneItemTransformChanged
+ * @eventSubscription SceneItems
  * @complexity 4
  * @rpcVersion -1
  * @initialVersion 5.0.0
@@ -282,9 +282,6 @@ void EventHandler::HandleSceneItemSelected(void *param, calldata_t *data)
 void EventHandler::HandleSceneItemTransformChanged(void *param, calldata_t *data)
 {
 	auto eventHandler = static_cast<EventHandler *>(param);
-
-	if (!eventHandler->_sceneItemTransformChangedRef.load())
-		return;
 
 	obs_scene_t *scene = GetCalldataPointer<obs_scene_t>(data, "scene");
 	if (!scene)
@@ -303,5 +300,5 @@ void EventHandler::HandleSceneItemTransformChanged(void *param, calldata_t *data
 	eventData["sceneUuid"] = obs_source_get_uuid(obs_scene_get_source(scene));
 	eventData["sceneItemId"] = obs_sceneitem_get_id(sceneItem);
 	eventData["sceneItemTransform"] = Utils::Obs::ObjectHelper::GetSceneItemTransform(sceneItem);
-	eventHandler->BroadcastEvent(EventSubscription::SceneItemTransformChanged, "SceneItemTransformChanged", eventData);
+	eventHandler->BroadcastEvent(EventSubscription::SceneItems, "SceneItemTransformChanged", eventData);
 }

--- a/src/eventhandler/types/EventSubscription.h
+++ b/src/eventhandler/types/EventSubscription.h
@@ -209,16 +209,5 @@ namespace EventSubscription {
 		* @api enums
 		*/
 		InputShowStateChanged = (1 << 18),
-		/**
-		* Subscription value to receive the `SceneItemTransformChanged` high-volume event.
-		*
-		* @enumIdentifier SceneItemTransformChanged
-		* @enumValue (1 << 19)
-		* @enumType EventSubscription
-		* @rpcVersion -1
-		* @initialVersion 5.0.0
-		* @api enums
-		*/
-		SceneItemTransformChanged = (1 << 19),
 	};
 }


### PR DESCRIPTION
### Description
This PR fixes #1295. Unify SceneItemTransformChanged under the general SceneItems subscription:

- Removed EventSubscription::SceneItemTransformChanged enum value and related _sceneItemTransformChangedRef counter logic.
- Updated event metadata (@eventSubscription tag) and BroadcastEvent calls to use EventSubscription::SceneItems.
- Eliminated redundant runtime check that suppressed the event when no dedicated subscribers existed (now covered by normal SceneItems subscription filtering).

### Motivation and Context
The SceneItemTransformChanged event was effectively broken: the dedicated ref counter (_sceneItemTransformChangedRef) was never incremented for normal SceneItems subscriptions, so the early ref check caused the handler to return every time. As a result, clients subscribing to SceneItems did not receive transform change events. Removing the unused subscription flag, its ref bookkeeping, and the premature check fixes the dispatch and simplifies the API.

### How Has This Been Tested?

1. Subscribed with SceneItems only; verified SceneItemTransformChanged now received on item move/resize.
2. Unsubscribed; verified events cease.
3. Regression: Other SceneItems events (create/remove/select) still delivered.
4. Monitored for unintended extra events (none observed). Tested OS(s): Windows 11 x64.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
