### PR TITLE
requesthandler: Fix `release` field not read for `SetTBarPosition`

### DIFF
--- a/src/requesthandler/RequestHandler_Transitions.cpp
+++ b/src/requesthandler/RequestHandler_Transitions.cpp
@@ -315,6 +315,7 @@ RequestResult RequestHandler::SetTBarPosition(const Request &request)
 	if (request.Contains("release")) {
 		if (!request.ValidateOptionalBoolean("release", statusCode, comment))
 			return RequestResult::Error(statusCode, comment);
+		release = request.RequestData["release"];
 	}
 
 	OBSSourceAutoRelease transition = obs_frontend_get_current_transition();


### PR DESCRIPTION
### Description
Sets the `release` variable inside of the `SetTBarPosition` request function to a value provided in the request field, as per intended behaviour.

### Motivation and Context
Partially resolves [issue 1211](https://github.com/obsproject/obs-websocket/issues/1211), as the other part of the issue is related to an OBS bug.

### How Has This Been Tested?
I've tested this fix with a program that sends the SetTBarPosition request every time a physical T-bar is moved.
Tested OS(s): Ubuntu 24.04

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
