### PR TITLE
utils: Fix crash getting profile or scene collection during OBS shutdown

### DIFF
--- a/src/utils/Obs_StringHelper.cpp
+++ b/src/utils/Obs_StringHelper.cpp
@@ -49,19 +49,19 @@ std::string Utils::Obs::StringHelper::GetModuleConfigPath(std::string fileName)
 std::string Utils::Obs::StringHelper::GetCurrentSceneCollection()
 {
 	BPtr<char> sceneCollectionName = obs_frontend_get_current_scene_collection();
-	return std::string(sceneCollectionName.Get());
+	return std::string(sceneCollectionName ? sceneCollectionName.Get() : "");
 }
 
 std::string Utils::Obs::StringHelper::GetCurrentProfile()
 {
 	BPtr<char> profileName = obs_frontend_get_current_profile();
-	return std::string(profileName.Get());
+	return std::string(profileName ? profileName.Get() : "");
 }
 
 std::string Utils::Obs::StringHelper::GetCurrentProfilePath()
 {
 	BPtr<char> profilePath = obs_frontend_get_current_profile_path();
-	return std::string(profilePath.Get());
+	return std::string(profilePath ? profilePath.Get() : "");
 }
 
 std::string Utils::Obs::StringHelper::GetCurrentRecordOutputPath()


### PR DESCRIPTION


### Description
Fix crash getting profile or scene collection during shutdown of OBS

### Motivation and Context
No more crashes

### How Has This Been Tested?
continuously requests during shutdown of OBS
Tested OS(s): Windows 11

### Types of changes

- Bug fix (non-breaking change which fixes an issue) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
