### PR TITLE
forms: Fix issue with Qt 6.8.3 and Clang 21

### DIFF
--- a/src/forms/SettingsDialog.cpp
+++ b/src/forms/SettingsDialog.cpp
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
-#include <QtWidgets/QMessageBox>
+#include <QMessageBox>
 #include <QDateTime>
 #include <QTime>
 #include <obs-module.h>


### PR DESCRIPTION
### Description
Changes include for `QMessageBox` to use the default umbrella header.

### Motivation and Context
Clang 21 enabled built-in support for "__yield" but requires including "arm_acle.h" to work. Qt's "qyieldcpu" header will emit code using the function without including the declaration and thus fail compilation

A fix for Qt is pending, but AppleClang 21 is shipped since 2026-03-24 with Xcode 26.4 and thus the project cannot be compiled after a toolchain update otherwise.

For an unknown reason, using the umbrella header fixes the issue.

### How Has This Been Tested?
Tested OS(s): macOS 26 with Xcode 26.4

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
