### PR TITLE
Requests: Give correct MIME in `GetSourceScreenshot`

### DIFF
--- a/src/requesthandler/RequestHandler_Sources.cpp
+++ b/src/requesthandler/RequestHandler_Sources.cpp
@@ -22,6 +22,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QFileInfo>
 #include <QImage>
 #include <QDir>
+#include <QMimeDatabase>
+#include <QMimeType>
 
 #include "RequestHandler.h"
 
@@ -187,6 +189,15 @@ RequestResult RequestHandler::GetSourceScreenshot(const Request &request)
 		return RequestResult::Error(RequestStatus::InvalidRequestField,
 					    "Your specified image format is invalid or not supported by this system.");
 
+	// Used to get the correct MIME type that is compatible with web browsers.
+	// Ex: Both when requested "imageFormat" is "jpeg" and "jpg", the returned MIME type should be "image/jpeg" for both.
+	// See Issue #1298
+	QMimeDatabase mimeDatabase;
+	// Create fake file path with user requested image format(file extension)
+	QString fileName = QString::fromStdString("1." + imageFormat);
+	QMimeType mimeType = mimeDatabase.mimeTypeForFile(QFileInfo(fileName));
+	QString responseMimeStr = mimeType.name();
+
 	uint32_t requestedWidth{0};
 	uint32_t requestedHeight{0};
 	int compressionQuality{-1};
@@ -227,10 +238,11 @@ RequestResult RequestHandler::GetSourceScreenshot(const Request &request)
 
 	buffer.close();
 
-	QString encodedPicture = QString("data:image/%1;base64,").arg(imageFormat.c_str()).append(encodedImgBytes.toBase64());
+	QString encodedPicture = QString("data:%1;base64,").arg(responseMimeStr).append(encodedImgBytes.toBase64());
 
 	json responseData;
 	responseData["imageData"] = encodedPicture.toStdString();
+
 	return RequestResult::Success(responseData);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Adds to `GetSourceScreenshot` the code to look up the correct MIME type for the requested image format and returns the base64 string with the correct MIME type. The lookup of the correct MIME types for each file formats is done using Qt library's QMimeDatabase Object.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
This PR solves this [issue](https://github.com/obsproject/obs-websocket/issues/1298).
The original code for `GetSourceScreenshot` got the MIME type by simply appending the requested image format to `image/`.
In some cases, this causes the response MIME type to be an invalid MIME type.
For Example, when making a `GetSourceScreenshot` request with the image format parameter of `{'imageFormat': 'jpg'}`, the original code returns a base64 string with the MIME type `image/jpg`, which is not an official valid MIME type.
This causes issues in rendering with certain browsers or software.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): macOS 26.02, Windows 11
Made `GetSourceScreenshot` requests with each supported image format and confirmed that the response is a base64 string starting with the [official MIME types](https://www.iana.org/assignments/media-types/media-types.xhtml)
For Example, both requests made with  `{'imageFormat': 'jpg'}` and  `{'imageFormat': 'jpeg'}` respond with the valid MIME type `image/jpeg`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
