### PR TITLE
Update lambas for C++20

### DIFF
--- a/src/forms/SettingsDialog.cpp
+++ b/src/forms/SettingsDialog.cpp
@@ -260,7 +260,8 @@ void SettingsDialog::FillSessionTable()
 		invalidateButtonLayout->setContentsMargins(0, 0, 0, 0);
 		invalidateButtonWidget->setLayout(invalidateButtonLayout);
 		ui->websocketSessionTable->setCellWidget(i, 4, invalidateButtonWidget);
-		connect(invalidateButton, &QPushButton::clicked, [=]() { webSocketServer->InvalidateSession(session.hdl); });
+		connect(invalidateButton, &QPushButton::clicked,
+			[webSocketServer, session]() { webSocketServer->InvalidateSession(session.hdl); });
 
 		i++;
 	}

--- a/src/websocketserver/WebSocketServer.cpp
+++ b/src/websocketserver/WebSocketServer.cpp
@@ -349,7 +349,7 @@ void WebSocketServer::onMessage(websocketpp::connection_hdl hdl,
 {
 	auto opCode = message->get_opcode();
 	std::string payload = message->get_payload();
-	_threadPool.start(Utils::Compat::CreateFunctionRunnable([=]() {
+	_threadPool.start(Utils::Compat::CreateFunctionRunnable([hdl, payload, opCode, this]() {
 		std::unique_lock<std::mutex> lock(_sessionMutex);
 		SessionPtr session;
 		try {

--- a/src/websocketserver/WebSocketServer_Protocol.cpp
+++ b/src/websocketserver/WebSocketServer_Protocol.cpp
@@ -359,7 +359,7 @@ void WebSocketServer::BroadcastEvent(uint64_t requiredIntent, const std::string 
 	if (!_server.is_listening() || !_obsReady)
 		return;
 
-	_threadPool.start(Utils::Compat::CreateFunctionRunnable([=]() {
+	_threadPool.start(Utils::Compat::CreateFunctionRunnable([eventType, requiredIntent, eventData, rpcVersion, this]() {
 		// Populate message object
 		json eventMessage;
 		eventMessage["op"] = 5;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Replace implicit lambda captures to be explicit for C++20 compliance while retaining C++17 compatibility.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

Want obs-studio and its submodules to build with C++20 some day.

However, websocketpp, used by obs-websocket, is not C++20 compatible, so we will need to choose one of the following options:
1. Patch websocketpp.
2. Build obs-websocket as C++17 while the rest of the project builds as C++20.
3. Replace websocketpp.

That said, I wanted to at least push the required obs-websocket changes here for visibility/review.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 11

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
